### PR TITLE
Chore: Add more test assertions

### DIFF
--- a/test/average.spec.js
+++ b/test/average.spec.js
@@ -7,11 +7,28 @@ var Handlebars = require('handlebars');
 Handlebars.registerHelper(average.name, average);
 
 tape('average', function (test) {
-  var template = Handlebars.compile('{{average numbers}}');
-  var expected = '5';
-  var actual = template({
+  var template;
+  var expected;
+  var actual;
+
+  test.plan(2);
+
+  template = Handlebars.compile('{{average numbers}}');
+  expected = '5';
+  actual = template({
     numbers: [2, 4, 6, 8]
   });
-  test.plan(1);
   test.equal(actual, expected, 'Works');
+
+  template = Handlebars.compile('{{average items key="number"}}');
+  expected = '50';
+  actual = template({
+    items: [
+      { number: 20 },
+      { number: 40 },
+      { number: 60 },
+      { number: 80 }
+    ]
+  });
+  test.equal(actual, expected, 'Works with key hash');
 });

--- a/test/fraction.spec.js
+++ b/test/fraction.spec.js
@@ -9,11 +9,23 @@ Handlebars.registerHelper(fraction.name, fraction);
 
 tape('fraction', function (test) {
   var entities = new Entities();
-  var template = Handlebars.compile('{{{fraction number}}}');
-  var expected = '1¼';
-  var actual = entities.decode(template({
+  var actual;
+  var expected;
+  var template;
+
+  test.plan(2);
+
+  template = Handlebars.compile('{{{fraction number}}}');
+  expected = '1¼';
+  actual = entities.decode(template({
     number: 1.25
   }));
-  test.plan(1);
   test.equal(actual, expected, 'Works');
+
+  template = Handlebars.compile('{{{fraction number}}}');
+  expected = '1';
+  actual = entities.decode(template({
+    number: 1
+  }));
+  test.equal(actual, expected, 'Ignores non-fractions');
 });

--- a/test/random.spec.js
+++ b/test/random.spec.js
@@ -8,10 +8,18 @@ Handlebars.registerHelper(random.name, random);
 
 tape('random', function (test) {
   var template = Handlebars.compile('{{random items}}');
-  var items = ['a', 'b', 'c'];
-  var result = template({ items: items });
-  var inArray = items.indexOf(result) !== -1;
+  var items;
+  var result;
 
-  test.plan(1);
-  test.ok(inArray, 'Works');
+  test.plan(2);
+
+  items = ['a', 'b', 'c'];
+  result = template({ items: items });
+  test.ok(items.indexOf(result) !== -1, 'Works');
+
+  try {
+    result = template({ items: 'not an array' });
+  } catch (err) {
+    test.pass('Errors when passed a non-array');
+  }
 });

--- a/test/random.spec.js
+++ b/test/random.spec.js
@@ -17,9 +17,11 @@ tape('random', function (test) {
   result = template({ items: items });
   test.ok(items.indexOf(result) !== -1, 'Works');
 
-  try {
-    result = template({ items: 'not an array' });
-  } catch (err) {
-    test.pass('Errors when passed a non-array');
-  }
+  test.throws(
+    function () {
+      template({ items: 'not an array' })
+    },
+    /passed an Array\.$/,
+    'Errors when passed a non-array'
+  );
 });

--- a/test/slug.spec.js
+++ b/test/slug.spec.js
@@ -8,10 +8,32 @@ Handlebars.registerHelper(slug.name, slug);
 
 tape('slug', function (test) {
   var template = Handlebars.compile('{{slug title}}');
-  var expected = 'some-title';
-  var actual = template({
-    title: 'Some Title'
-  });
-  test.plan(1);
-  test.equal(actual, expected, 'Works');
+  var actual;
+  var expected;
+
+  test.plan(6);
+
+  expected = '1';
+  actual = template({ title: 1 });
+  test.equal(actual, expected, 'Converts input to a string');
+
+  expected = 'lowercase';
+  actual = template({ title: 'LoWeRcAsE' });
+  test.equal(actual, expected, 'Converts input to lowercase');
+
+  expected = 'many-words';
+  actual = template({ title: 'Many Words' });
+  test.equal(actual, expected, 'Replaces spaces with hyphens');
+
+  expected = 'a-b-c-1-2-3';
+  actual = template({ title: '!a@b#c$1%2^3&' });
+  test.equal(actual, expected, 'Replaces non-words with hyphens');
+
+  expected = 'one-hyphen';
+  actual = template({ title: 'One--Hyphen' });
+  test.equal(actual, expected, 'Replaces sequential hyphens');
+
+  expected = 'title';
+  actual = template({ title: '-Title-' });
+  test.equal(actual, expected, 'Trims leading and trailing hyphens');
 });

--- a/test/timestamp.spec.js
+++ b/test/timestamp.spec.js
@@ -7,11 +7,24 @@ var Handlebars = require('handlebars');
 Handlebars.registerHelper(timestamp.name, timestamp);
 
 tape('timestamp', function (test) {
-  var template = Handlebars.compile('{{timestamp date}}');
-  var expected = '1995-08-09';
-  var actual = template({
-    date: Date.parse('Aug 9, 1995')
-  });
-  test.plan(1);
+  var template;
+  var actual;
+  var expected;
+
+  test.plan(3);
+
+  template = Handlebars.compile('{{timestamp date}}');
+  expected = '1995-08-09';
+  actual = template({ date: Date.parse('Aug 9, 1995') });
   test.equal(actual, expected, 'Works');
+
+  template = Handlebars.compile('{{timestamp date format="MMM Do YY"}}');
+  expected = 'Aug 9th 95';
+  actual = template({ date: Date.parse('Aug 9, 1995') });
+  test.equal(actual, expected, 'Works with a specified format');
+
+  template = Handlebars.compile('{{timestamp date format="YYYY"}}');
+  expected = '2045';
+  actual = template({ date: '2045-01-01' });
+  test.equal(actual, expected, 'Works with a string input value');
 });


### PR DESCRIPTION
This adds more meaningful test assertions for the following:

- average
- fraction
- random
- slug
- timestamp

The other helpers still just have very simple tests because they are very simple helpers.

***
CC @tylersticka @lyzadanger 