### PR TITLE
Chore: Rename translator helpers

### DIFF
--- a/lib/toFraction.js
+++ b/lib/toFraction.js
@@ -18,7 +18,7 @@ var fractionMap = {
   87: 8542
 };
 
-module.exports = function fraction (value) {
+module.exports = function toFraction (value) {
   var integer = Math.floor(value);
   var decimal = value - integer;
   var key = Math.floor(decimal * 100);

--- a/lib/toSlug.js
+++ b/lib/toSlug.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function slug (str) {
+module.exports = function toSlug (str) {
   return str
     .toString()
     .toLowerCase()

--- a/lib/toTitle.js
+++ b/lib/toTitle.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = function displayName (name) {
+module.exports = function toTitle (name) {
   var pattern = /^[0-9]{0,4}[-_]?\s+?/;
   return name.replace(pattern, '');
 };

--- a/test/toFraction.spec.js
+++ b/test/toFraction.spec.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var fraction = require('../').fraction;
+var toFraction = require('../').toFraction;
 var tape = require('tape');
 var Entities = require('html-entities').Html5Entities;
 var Handlebars = require('handlebars');
 
-Handlebars.registerHelper(fraction.name, fraction);
+Handlebars.registerHelper(toFraction.name, toFraction);
 
-tape('fraction', function (test) {
+tape('toFraction', function (test) {
   var entities = new Entities();
   var actual;
   var expected;
@@ -15,14 +15,14 @@ tape('fraction', function (test) {
 
   test.plan(2);
 
-  template = Handlebars.compile('{{{fraction number}}}');
+  template = Handlebars.compile('{{{toFraction number}}}');
   expected = '1¼';
   actual = entities.decode(template({
     number: 1.25
   }));
   test.equal(actual, expected, 'Works');
 
-  template = Handlebars.compile('{{{fraction number}}}');
+  template = Handlebars.compile('{{{toFraction number}}}');
   expected = '1';
   actual = entities.decode(template({
     number: 1

--- a/test/toSlug.spec.js
+++ b/test/toSlug.spec.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var slug = require('../').slug;
+var toSlug = require('../').toSlug;
 var tape = require('tape');
 var Handlebars = require('handlebars');
 
-Handlebars.registerHelper(slug.name, slug);
+Handlebars.registerHelper(toSlug.name, toSlug);
 
-tape('slug', function (test) {
-  var template = Handlebars.compile('{{slug title}}');
+tape('toSlug', function (test) {
+  var template = Handlebars.compile('{{toSlug title}}');
   var actual;
   var expected;
 

--- a/test/toTitle.spec.js
+++ b/test/toTitle.spec.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var displayName = require('../').displayName;
+var toTitle = require('../').toTitle;
 var tape = require('tape');
 var Handlebars = require('handlebars');
 
-Handlebars.registerHelper(displayName.name, displayName);
+Handlebars.registerHelper(toTitle.name, toTitle);
 
-tape('displayName', function (test) {
-  var template = Handlebars.compile('{{displayName title}}');
+tape('toTitle', function (test) {
+  var template = Handlebars.compile('{{toTitle title}}');
   var expected = 'title';
   var actual = template({
     title: '01 title'


### PR DESCRIPTION
Closes #4

This renames a number of helpers to use the format of `toSomething` in order to clarify their method of operation.

***
CC @saralohr 