### PR TITLE
Refactor timestamp helper

### DIFF
--- a/lib/timestamp.js
+++ b/lib/timestamp.js
@@ -1,29 +1,55 @@
 'use strict';
 
+var moment = require('moment');
+var R = require('ramda');
+
+var defaults = {
+  format: undefined,
+  inputFormat: undefined,
+  utc: true
+};
+
 /**
  * Format a date or time using <a href="http://momentjs.com/">Moment.js</a>.
  *
+ * Defaults to UTC mode since most use-cases in markup-land do not take
+ * timezones into account, which results in some counter-intuitive output and
+ * inconsistent behavior.
+ *
  * @since v0.0.1
- * @param {Date|String|Number} context
+ * @param {Date|String|Number|Array|Object} [context]
  * @return {String}
  * @example
  *
  *   {{timestamp "2015-10-21" format="MMM Do, YYYY"}} //=> "Oct 21st, 2015"
+ *
+ *   {{timestamp "Oct 21 15" inputFormat="MMM DD YY" format="YYYY-MM-DD"}} //=> "2015-10-21"
+ *
+ *   {{timestamp "2000-01-01" format="YYYY" utc=false}} //=> "1999"
  */
 
-var moment = require('moment');
-var defaultFormat = 'YYYY-MM-DD';
+module.exports = function timestamp (context, block) {
+  var options, constructor, date;
 
-module.exports = function timestamp (fromDate, options) {
-  var date = options ? fromDate : Date.now();
-  var opts = options || fromDate;
-  var format = opts.hash.format || defaultFormat;
-  var isInvalid = isNaN(Date.parse(date));
+  if (context && context.hash) {
+    block = context;
+    context = undefined;
+  }
 
-  if (isInvalid) {
+  options = (block && block.hash) ? R.merge(defaults, block.hash) : R.clone(defaults);
+  constructor = (options.utc) ? moment.utc : moment;
+
+  if (R.is(String, context) && R.isNil(options.inputFormat)) {
+    context = Date.parse(context);
+  }
+
+  date = constructor(context, options.inputFormat);
+
+  if (!date.isValid()) {
     throw new Error(
-      'The "timestamp" helper must be passed a Date-parseable value.'
+      'The "timestamp" helper must be passed a valid Date-like value.'
     );
   }
-  return moment(date).format(format);
+
+  return date.format(options.format);
 };

--- a/test/timestamp.spec.js
+++ b/test/timestamp.spec.js
@@ -10,29 +10,58 @@ tape('timestamp', function (test) {
   var template;
   var actual;
   var expected;
+  var iso8601 = /(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})[+-](\d{2})\:(\d{2})/;
+  var today = new Date();
 
-  test.plan(4);
+  test.plan(7);
 
-  template = Handlebars.compile('{{timestamp date}}');
-  expected = '1995-08-09';
-  actual = template({ date: new Date('Aug 9, 1995') });
+  template = Handlebars.compile('{{timestamp}}');
+  expected = true;
+  actual = (template().match(iso8601).length > 0);
   test.equal(actual, expected, 'Works');
 
-  test.throws(
-    function () {
-      template({ date: 'abc123' })
-    },
-    /Date-parseable value\.$/,
-    'Errors when passed an invalid date value'
-  );
+  template = Handlebars.compile('{{timestamp format="YYYY"}}');
+  expected = today.getFullYear().toString();
+  actual = template();
+  test.equal(actual, expected, 'Works with a specified format');
 
   template = Handlebars.compile('{{timestamp date format="MMM Do YY"}}');
   expected = 'Aug 9th 95';
   actual = template({ date: new Date('Aug 9, 1995') });
-  test.equal(actual, expected, 'Works with a specified format');
+  test.equal(actual, expected, 'Works with Date input');
 
-  template = Handlebars.compile('{{timestamp date format="YYYY"}}');
-  expected = '2045';
-  actual = template({ date: '2045-01-01' });
-  test.equal(actual, expected, 'Works with a string input value');
+  template = Handlebars.compile('{{timestamp date format="MMM Do, YYYY"}}');
+  expected = 'Oct 21st, 2015';
+  actual = template({ date: '2015-10-21' });
+  test.equal(actual, expected, 'Works with string input');
+
+  template = Handlebars.compile('{{timestamp date inputFormat="MMM DD YY" format="YYYY-MM-DD"}}');
+  expected = '2015-10-21';
+  actual = template({ date: 'Oct 21 15' });
+  test.equal(actual, expected, 'Works with custom input format');
+
+  template = Handlebars.compile('{{timestamp format="ZZ" utc=false}}');
+  expected = (function (date) {
+    var offset = today.getTimezoneOffset() / 0.6;
+    var result = '';
+    if (offset > 0) {
+      result += '-';
+      if (offset.toString().length < 4) {
+        result += '0';
+      }
+      result += offset;
+    }
+    return result;
+  })(today);
+  actual = template();
+  test.equal(actual, expected, 'Maintains timezone offset in non-UTC mode');
+
+  template = Handlebars.compile('{{timestamp date}}');
+  test.throws(
+    function () {
+      template({ date: 'abc123' });
+    },
+    /valid Date-like value\.$/,
+    'Errors when passed an invalid date value'
+  );
 });

--- a/test/timestamp.spec.js
+++ b/test/timestamp.spec.js
@@ -16,9 +16,7 @@ tape('timestamp', function (test) {
   test.plan(7);
 
   template = Handlebars.compile('{{timestamp}}');
-  expected = true;
-  actual = (template().match(iso8601).length > 0);
-  test.equal(actual, expected, 'Works');
+  test.ok(template().match(iso8601).length > 0, 'Works');
 
   template = Handlebars.compile('{{timestamp format="YYYY"}}');
   expected = today.getFullYear().toString();


### PR DESCRIPTION
Closes #11 

This PR introduces the following changes to the `timestamp` helper:

- Defaults to `UTC` mode. Anything other than this results in unexpected behavior in _most_ use-cases relevant to our organization. This can be overruled from any template, though.
- No more default format (Moment.js already has a default format).
- Better parsing of the initial date value. If the value is a string and `inputFormat` is specified, it uses Moment's awesome built-in date-parsing logic. If the value is a string but there's no `inputFormat`, it falls back to the system's `Date.parse` (avoiding Moment's warning about this in the process).
- Date validation is handled by `moment.isValid` now (rather than `isNaN`).
- More tests added to account for all the helper-specific options.