### PR TITLE
Add `around` helper

### DIFF
--- a/lib/around.js
+++ b/lib/around.js
@@ -1,0 +1,71 @@
+'use strict';
+
+var R = require('ramda');
+
+var defaults = {
+  offset: 0
+};
+
+/**
+ * Slices a list based on a center-point and a maximum amount of "padding"
+ * before and after. Useful for pagination.
+ *
+ * Supports an optional <code>offset</code> hash option in case your center
+ * value isn't matching up with your array indexes.
+ *
+ * @since v0.0.1
+ * @param {Array} items - Collection to iterate over.
+ * @param {Number} center - The center-point of the collection (for example, current page).
+ * @param {Number} padding - The amount of items to allow before or after the center.
+ * @param {Object} block
+ * @return {String}
+ * @example
+ *
+ *   <ul>
+ *     {{#around pages 5 2 offset=-1}}
+ *       <li><a href="/page/{{num}}">Page {{num}}</a></li>
+ *     {{/around}}
+ *   </ul>
+ *
+ *   {{! Output: }}
+ *   <ul>
+ *     <li><a href="/page/3">Page 3</a></li>
+ *     <li><a href="/page/4">Page 4</a></li>
+ *     <li><a href="/page/5">Page 5</a></li>
+ *     <li><a href="/page/6">Page 6</a></li>
+ *     <li><a href="/page/7">Page 7</a></li>
+ *   </ul>
+ */
+
+module.exports = function around (items, center, padding, block) {
+  var result = '';
+  var options = (block && block.hash) ?  R.merge(defaults, block.hash) : R.clone(defaults);
+  var max, start, end;
+
+  center = parseFloat(center) + options.offset;
+  padding = parseFloat(padding);
+  max = padding * 2 + 1;
+
+  if (items.length > max) {
+    start = center - padding;
+    end = center + padding + 1;
+
+    if (start < 0) {
+      end -= start;
+      start = 0;
+    }
+
+    if (end > items.length) {
+      start -= end - items.length;
+      end = items.length;
+    }
+
+    items = items.slice(start, end);
+  }
+
+  for (var item in items) {
+    result += block.fn(items[item]);
+  }
+
+  return result;
+};

--- a/test/around.spec.js
+++ b/test/around.spec.js
@@ -1,0 +1,60 @@
+'use strict';
+
+var around = require('../').around;
+var tape = require('tape');
+var Handlebars = require('handlebars');
+
+Handlebars.registerHelper(around.name, around);
+
+tape('around', function (test) {
+  var template;
+  var expected;
+  var actual;
+  var items = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+  test.plan(5);
+
+  template = Handlebars.compile('{{#around items center padding}}{{.}}{{/around}}');
+
+  expected = '34567';
+  actual = template({
+    center: 4,
+    padding: 2,
+    items: items
+  });
+  test.equal(actual, expected, 'Works');
+
+  expected = '12345';
+  actual = template({
+    center: 1,
+    padding: 2,
+    items: items
+  });
+  test.equal(actual, expected, 'Works when center is below left padding');
+
+  expected = '56789';
+  actual = template({
+    center: 7,
+    padding: 2,
+    items: items
+  });
+  test.equal(actual, expected, 'Works when center is above right padding');
+
+  template = Handlebars.compile('{{#around items center padding offset=-1}}{{.}}{{/around}}');
+
+  expected = '34567';
+  actual = template({
+    center: 5,
+    padding: 2,
+    items: items
+  });
+  test.equal(actual, expected, 'Adjusts center based on offset value');
+
+  expected = '123456789';
+  actual = template({
+    center: 5,
+    padding: 100,
+    items: items
+  });
+  test.equal(actual, expected, 'Works when padding exceeds length');
+});


### PR DESCRIPTION
This is a tweaked version of a helper I've found to be really helpful (heh) in my personal projects. It accepts an array, a center-point, and an amount of padding, and returns a sliced collection based on those values. It's especially useful for pagination, where you want individual page-number links but you don't want it to stretch off if there are a hundred pages.