### PR TITLE
Feature: toJSON helper

### DIFF
--- a/lib/toJSON.js
+++ b/lib/toJSON.js
@@ -8,10 +8,6 @@
  * @return {Array|Object}
  * @example
  *
- *    {{toJSON '[1,2,3]'}} //=> [1, 2, 3]
- *
- *    {{toJSON '{"foo": "bar"}'}} //=> {"foo": "bar"}
- *
  *    {{#each (toJSON '[1,2,3]')}}{{this}}{{/each}} //=> '123'
  */
 

--- a/lib/toJSON.js
+++ b/lib/toJSON.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * Converts a string to JSON; useful when used in helper sub-expressions.
+ *
+ * @since v0.0.1
+ * @param {String} str
+ * @return {Array|Object}
+ * @example
+ *
+ *    {{toJSON '[1,2,3]'}} //=> [1, 2, 3]
+ *
+ *    {{toJSON '{"foo": "bar"}'}} //=> {"foo": "bar"}
+ *
+ *    {{#each (toJSON '[1,2,3]')}}{{this}}{{/each}} //=> '123'
+ */
+
+module.exports = function toJSON (str) {
+  str = str.toString();
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    throw new Error(
+      'The "toJSON" helper must be passed a valid JSON string.'
+    );
+  }
+};

--- a/test/toJSON.spec.js
+++ b/test/toJSON.spec.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var toJSON = require('../').toJSON;
+var tape = require('tape');
+var Handlebars = require('handlebars');
+
+Handlebars.registerHelper(toJSON.name, toJSON);
+
+tape('toJSON', function (test) {
+  var template = Handlebars.compile('{{#each (toJSON data)}}{{this}}{{/each}}');
+  var actual;
+  var expected;
+
+  test.plan(5);
+
+  expected = '123';
+  actual = template({ data: '[1, 2, 3]' });
+  test.equal(actual, expected, 'Handles arrays');
+
+  expected = 'abc';
+  actual = template({ data: '{"0":"a", "1":"b", "2":"c"}' });
+  test.equal(actual, expected, 'Handles objects');
+
+  template = Handlebars.compile('{{#each (toJSON "[1, 2, 3]")}}{{this}}{{/each}}');
+  expected = '123';
+  actual = template();
+  test.equal(actual, expected, 'Handles array literals');
+
+  template = Handlebars.compile('{{#each (toJSON \'{\"foo\": \"bar\"}\')}}{{this}}{{/each}}');
+  expected = 'bar';
+  actual = template();
+  test.equal(actual, expected, 'Handles object literals');
+
+  template = Handlebars.compile('{{toJSON data}}');
+  test.throws(
+    function () {
+      template({ data: 'not JSON' });
+    },
+    /must be passed a valid JSON string\.$/,
+    'Errors when passed invalid JSON'
+  );
+});


### PR DESCRIPTION
This adds a new helper for converting strings to JSON. This is mainly
useful when combined with other helpers, for example:

```hbs
{{#each (toJSON "[1,2,3]")}}
  <li>{{@index}}: {{this}}</li>
{{/each}}
```

CC @lyzadanger 