### PR TITLE
Feature: defaultTo helper

### DIFF
--- a/lib/defaultTo.js
+++ b/lib/defaultTo.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var R = require('ramda');
+
+/**
+ * Output a value if it exists, or fallback to a default if it does not.
+ *
+ * @since v0.0.1
+ * @param {*} value
+ * @param {*} fallback
+ * @param {Object} options
+ * @return {String}
+ * @example
+ *
+ *  var doesExist = 'Hello';
+ *
+ *  {{defaultTo doesExist "Goodbye"}} // => "Hello"
+ *  {{defaultTo doesNotExist "Goodbye"}} // => "Goodbye"
+ *  {{defaultTo doesNotExist}} // => ""
+ */
+
+module.exports = function defaultTo (value, fallback, options) {
+  var defaultBlank = R.defaultTo('');
+  var defaultFallback = R.defaultTo(fallback);
+  return R.isNil(options) ?
+    defaultBlank(value) : R.pipe(defaultFallback, defaultBlank)(value);
+};

--- a/test/defaultTo.spec.js
+++ b/test/defaultTo.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var defaultTo = require('../').defaultTo;
+var tape = require('tape');
+var Handlebars = require('handlebars');
+
+Handlebars.registerHelper(defaultTo.name, defaultTo);
+
+tape('defaultTo', function (test) {
+  var template;
+  var expected;
+  var actual;
+
+  test.plan(3);
+
+  template = Handlebars.compile('{{defaultTo doesExist "Goodbye"}}');
+  expected = 'Hello';
+  actual = template({ doesExist: 'Hello' });
+  test.equal(actual, expected, 'Works with value set');
+
+  template = Handlebars.compile('{{defaultTo doesNotExist "Goodbye"}}');
+  expected = 'Goodbye';
+  actual = template({});
+  test.equal(actual, expected, 'Works with value not set');
+
+  template = Handlebars.compile('{{defaultTo doesNotExist}}');
+  expected = '';
+  actual = template({});
+  test.equal(actual, expected, 'Works with value and fallback not set');
+});


### PR DESCRIPTION
This adds a new helper to handle the common case of doing something like:

```hbs
{{if value}}{{value}}{{else}}default{{/if}}
```

Using the helper:

```hbs
{{defaultTo value "default"}}
```

CC @lyzadanger 