### PR TITLE
Support variable arguments for defaultTo helper

### DIFF
--- a/lib/defaultTo.js
+++ b/lib/defaultTo.js
@@ -3,12 +3,11 @@
 var R = require('ramda');
 
 /**
- * Output a value if it exists, or fallback to a default if it does not.
+ * Output the first provided value that exists, or fallback to a default if
+ * none do.
  *
  * @since v0.0.1
- * @param {*} value
- * @param {*} fallback
- * @param {Object} options
+ * @param {...*} value
  * @return {String}
  * @example
  *
@@ -17,11 +16,10 @@ var R = require('ramda');
  *  {{defaultTo doesExist "Goodbye"}} // => "Hello"
  *  {{defaultTo doesNotExist "Goodbye"}} // => "Goodbye"
  *  {{defaultTo doesNotExist}} // => ""
+ *  {{defaultTo doesNotExist doesExist "Goodbye"}} // => "Hello"
  */
 
-module.exports = function defaultTo (value, fallback, options) {
-  var defaultBlank = R.defaultTo('');
-  var defaultFallback = R.defaultTo(fallback);
-  return R.isNil(options) ?
-    defaultBlank(value) : R.pipe(defaultFallback, defaultBlank)(value);
+module.exports = function defaultTo () {
+  var values = R.append('', R.dropLast(1, arguments));
+  return R.head(R.reject(R.isNil, values));
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-hbs-helpers",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Handlebars helpers that we usually need.",
   "main": "index.js",
   "files": [

--- a/test/defaultTo.spec.js
+++ b/test/defaultTo.spec.js
@@ -11,7 +11,7 @@ tape('defaultTo', function (test) {
   var expected;
   var actual;
 
-  test.plan(3);
+  test.plan(4);
 
   template = Handlebars.compile('{{defaultTo doesExist "Goodbye"}}');
   expected = 'Hello';
@@ -27,4 +27,9 @@ tape('defaultTo', function (test) {
   expected = '';
   actual = template({});
   test.equal(actual, expected, 'Works with value and fallback not set');
+
+  template = Handlebars.compile('{{defaultTo doesNotExist doesExist "Goodbye"}}');
+  expected = 'Hello';
+  actual = template({ doesExist: 'Hello' });
+  test.equal(actual, expected, 'Works with variable arguments');
 });


### PR DESCRIPTION
This PR updates the `defaultTo` helper to support variable arguments.

It also adds a test for variable arguments and bumps the version in `package.json`.

---

@erikjung @mrgerardorodriguez 

Closes #20