### PR TITLE
Allow random helper to accept multiple args

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -1,20 +1,33 @@
 'use strict';
 
+var R = require('ramda');
+
 /**
- * Return only one random item from an array.
+ * Return only one random item. If only one argument is provided and it is an
+ * array, it will return a random item from that array. Otherwise it will return
+ * one of the arguments.
  *
  * @since v0.0.1
- * @param {Array} arr
+ * @param {...*} items
  * @return One random item.
  * @example
  *
  *   var beatles = ["John", "Paul", "George", "Ringo"];
  *   {{random beatles}} //=> "George"
+ *
+ *   {{random "John" "Paul" "George" "Ringo"}} //=> "Ringo"
  */
 
-module.exports = function random (arr) {
-  var isArray = Array.isArray(arr);
-  if (!isArray)
-    throw new Error('The helper "random" must be passed an Array.');
-  return arr[Math.floor(Math.random() * arr.length)];
+module.exports = function random () {
+  var items = R.dropLast(1, arguments);
+
+  if (!items.length) {
+    throw new Error('The helper "random" must be passed at least one argument.');
+  }
+
+  if (items.length === 1) {
+    items = R.is(Array, items[0]) ? items[0] : [items[0]];
+  }
+
+  return items[Math.floor(Math.random() * items.length)];
 };

--- a/lib/randomItem.js
+++ b/lib/randomItem.js
@@ -13,16 +13,16 @@ var R = require('ramda');
  * @example
  *
  *   var beatles = ["John", "Paul", "George", "Ringo"];
- *   {{random beatles}} //=> "George"
+ *   {{randomItem beatles}} //=> "George"
  *
- *   {{random "John" "Paul" "George" "Ringo"}} //=> "Ringo"
+ *   {{randomItem "John" "Paul" "George" "Ringo"}} //=> "Ringo"
  */
 
-module.exports = function random () {
+module.exports = function randomItem () {
   var items = R.dropLast(1, arguments);
 
   if (!items.length) {
-    throw new Error('The helper "random" must be passed at least one argument.');
+    throw new Error('The helper "randomItem" must be passed at least one argument.');
   }
 
   if (items.length === 1) {

--- a/test/random.spec.js
+++ b/test/random.spec.js
@@ -7,21 +7,30 @@ var Handlebars = require('handlebars');
 Handlebars.registerHelper(random.name, random);
 
 tape('random', function (test) {
-  var template = Handlebars.compile('{{random items}}');
-  var items;
+  var items = ['a', 'b', 'c'];
+  var template;
   var result;
 
-  test.plan(2);
+  test.plan(4);
 
-  items = ['a', 'b', 'c'];
+  template = Handlebars.compile('{{random items}}');
   result = template({ items: items });
-  test.ok(items.indexOf(result) !== -1, 'Works');
+  test.ok(items.indexOf(result) !== -1, 'Works with a single Array');
 
+  template = Handlebars.compile('{{random "' + items.join('" "') + '"}}');
+  result = template();
+  test.ok(items.indexOf(result) !== -1, 'Works with multiple arguments');
+
+  template = Handlebars.compile('{{random "a"}}');
+  result = template();
+  test.equal(result, 'a', 'Works with only a single item');
+
+  template = Handlebars.compile('{{random}}');
   test.throws(
     function () {
-      template({ items: 'not an array' })
+      template();
     },
-    /passed an Array\.$/,
-    'Errors when passed a non-array'
+    /at least one argument\.$/,
+    'Errors when passed zero arguments'
   );
 });

--- a/test/randomItem.spec.js
+++ b/test/randomItem.spec.js
@@ -1,31 +1,31 @@
 'use strict';
 
-var random = require('../').random;
+var randomItem = require('../').randomItem;
 var tape = require('tape');
 var Handlebars = require('handlebars');
 
-Handlebars.registerHelper(random.name, random);
+Handlebars.registerHelper(randomItem.name, randomItem);
 
-tape('random', function (test) {
+tape('randomItem', function (test) {
   var items = ['a', 'b', 'c'];
   var template;
   var result;
 
   test.plan(4);
 
-  template = Handlebars.compile('{{random items}}');
+  template = Handlebars.compile('{{randomItem items}}');
   result = template({ items: items });
   test.ok(items.indexOf(result) !== -1, 'Works with a single Array');
 
-  template = Handlebars.compile('{{random "' + items.join('" "') + '"}}');
+  template = Handlebars.compile('{{randomItem "' + items.join('" "') + '"}}');
   result = template();
   test.ok(items.indexOf(result) !== -1, 'Works with multiple arguments');
 
-  template = Handlebars.compile('{{random "a"}}');
+  template = Handlebars.compile('{{randomItem "a"}}');
   result = template();
   test.equal(result, 'a', 'Works with only a single item');
 
-  template = Handlebars.compile('{{random}}');
+  template = Handlebars.compile('{{randomItem}}');
   test.throws(
     function () {
       template();


### PR DESCRIPTION
Sometimes it's helpful when prototyping to be able to pass along multiple arguments to choose from at random instead of an array. See `lib/random.js` example for more info.

---

@erikjung @mrgerardorodriguez 