### PR TITLE
Don't require triple-slash for toFraction helper

### DIFF
--- a/lib/toFraction.js
+++ b/lib/toFraction.js
@@ -1,5 +1,25 @@
 'use strict';
 
+var n2f = require('num2fraction');
+
+var vulgarities = {
+  '1/4': '¼',
+  '1/2': '½',
+  '3/4': '¾',
+  '1/3': '⅓',
+  '2/3': '⅔',
+  '1/5': '⅕',
+  '2/5': '⅖',
+  '3/5': '⅗',
+  '4/5': '⅘',
+  '1/6': '⅙',
+  '5/6': '⅚',
+  '1/8': '⅛',
+  '3/8': '⅜',
+  '5/8': '⅝',
+  '7/8': '⅞'
+};
+
 /**
  * Format a decimal as a fractional HTML entity if possible.
  *
@@ -8,36 +28,20 @@
  * @return {String|Number}
  * @example
  *
- *   {{toFraction 1.25}} //=> "1&#188;"
- *   {{toFraction 3.1666}} //=> "3&#8537;"
+ *   {{toFraction 1.25}} //=> "1¼"
+ *   {{toFraction 3.1666}} //=> "3⅙"
  *   {{toFraction 2.7}} //=> 2.7
  */
-
-var fractionMap = {
-  25: 188,
-  50: 189,
-  75: 190,
-  33: 8531,
-  66: 8532,
-  20: 8533,
-  40: 8534,
-  60: 8535,
-  80: 8536,
-  16: 8537,
-  83: 8538,
-  12: 8539,
-  37: 8540,
-  62: 8541,
-  87: 8542
-};
 
 module.exports = function toFraction (value) {
   var integer = Math.floor(value);
   var decimal = value - integer;
-  var key = Math.floor(decimal * 100);
+  var key = n2f(decimal);
+  var result = value;
 
-  if (fractionMap.hasOwnProperty(key)) {
-    value = integer + '&#' + fractionMap[key] + ';';
+  if (vulgarities.hasOwnProperty(key)) {
+    result = integer + vulgarities[key];
   }
-  return value;
+
+  return result;
 };

--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
     "chance": "^1.0.3",
     "handlebars": "^4.0.3",
     "moment": "^2.10.6",
+    "num2fraction": "^1.2.2",
     "ramda": "^0.18.0",
     "require-dir": "^0.3.0",
     "tinycolor2": "^1.3.0"
   },
   "devDependencies": {
-    "html-entities": "^1.2.0",
     "tap-spec": "^4.1.0",
     "tape": "^4.2.1"
   }

--- a/test/toFraction.spec.js
+++ b/test/toFraction.spec.js
@@ -2,30 +2,26 @@
 
 var toFraction = require('../').toFraction;
 var tape = require('tape');
-var Entities = require('html-entities').Html5Entities;
 var Handlebars = require('handlebars');
 
 Handlebars.registerHelper(toFraction.name, toFraction);
 
 tape('toFraction', function (test) {
-  var entities = new Entities();
-  var actual;
+  var template = Handlebars.compile('{{{toFraction number}}}');
   var expected;
-  var template;
+  var actual;
 
-  test.plan(2);
+  test.plan(3);
 
-  template = Handlebars.compile('{{{toFraction number}}}');
   expected = '1¼';
-  actual = entities.decode(template({
-    number: 1.25
-  }));
+  actual = template({ number: 1.25 });
   test.equal(actual, expected, 'Works');
 
-  template = Handlebars.compile('{{{toFraction number}}}');
   expected = '1';
-  actual = entities.decode(template({
-    number: 1
-  }));
+  actual = template({ number: 1 });
   test.equal(actual, expected, 'Ignores non-fractions');
+
+  expected = '1.42';
+  actual = template({ number: 1.42 });
+  test.equal(actual, expected, 'Ignores fractions with no applicable vulgarity');
 });


### PR DESCRIPTION
This PR uses unicode characters directly instead of escaped HTML because Handlebars already escapes HTML. This has the added benefit of no longer requiring triple-slashes (unless you want to use unescaped unicode in your compiled HTML).

This change adds a dependency on [`num2fraction`](https://github.com/yisibl/num2fraction) to improve rounding and simplify the helper logic. It removes the [`html-entities`](https://www.npmjs.com/package/html-entities) development dependency because the helper no longer requires decoding to succinctly test its output.

---

@erikjung @mrgerardorodriguez 

Fixes #33