### PR TITLE
Add math helper

### DIFF
--- a/lib/math.js
+++ b/lib/math.js
@@ -33,7 +33,7 @@ var operators = {
 
 module.exports = function math (left, operator, right, options) {
   if (arguments.length < 3) {
-    throw new Error('The "math" helper needs two arguments.');
+    throw new Error('The "math" helper needs at least two arguments.');
   }
 
   if (options === undefined) {

--- a/lib/math.js
+++ b/lib/math.js
@@ -8,6 +8,7 @@ var operators = {
   '*': R.multiply,
   '/': R.divide,
   '%': R.modulo,
+  '**': Math.pow,
   '++': R.inc,
   '--': R.dec
 };
@@ -27,6 +28,7 @@ var operators = {
  *  {{math 2 "*" 3}} //=> 6
  *  {{math 9 "/" 3}} //=> 3
  *  {{math 17 "%" 3}} //=> 2
+ *  {{math 2 "**" 3}} //=> 8
  *  {{math 1 "++"}} //=> 2
  *  {{math 2 "--"}} //=> 1
  */

--- a/lib/math.js
+++ b/lib/math.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var R = require('ramda');
+
+var operators = {
+  '+': R.add,
+  '-': R.subtract,
+  '*': R.multiply,
+  '/': R.divide,
+  '%': R.modulo,
+  '++': R.inc,
+  '--': R.dec
+};
+
+/**
+ * Perform mathematical operations on one or two values.
+ *
+ * @param {*} left
+ * @param {String} operator
+ * @param {*} right
+ * @param {Object} options
+ * @return {Number}
+ * @example:
+ *
+ *  {{math 1 "+" 2}} //=> 3
+ *  {{math 2 "-" 1}} //=> 1
+ *  {{math 2 "*" 3}} //=> 6
+ *  {{math 9 "/" 3}} //=> 3
+ *  {{math 17 "%" 3}} //=> 2
+ *  {{math 1 "++"}} //=> 2
+ *  {{math 2 "--"}} //=> 1
+ */
+
+module.exports = function math (left, operator, right, options) {
+  if (arguments.length < 3) {
+    throw new Error('The "math" helper needs two arguments.');
+  }
+
+  if (options === undefined) {
+    options = right;
+    right = undefined;
+  }
+
+  left = parseFloat(left);
+  right = parseFloat(right);
+
+  if (operators[operator] === undefined) {
+    throw new Error ('The "math" helper needs a valid operator.');
+  }
+
+  return operators[operator](left, right);
+}

--- a/test/math.spec.js
+++ b/test/math.spec.js
@@ -67,7 +67,7 @@ tape('math', function (test) {
     function () {
       template();
     },
-    /needs two arguments\.$/,
+    /needs at least two arguments\.$/,
     'Errors with too few arguments'
   );
 });

--- a/test/math.spec.js
+++ b/test/math.spec.js
@@ -1,0 +1,73 @@
+'use strict';
+
+var math = require('../').math;
+var tape = require('tape');
+var Handlebars = require('handlebars');
+
+Handlebars.registerHelper(math.name, math);
+
+tape('math', function (test) {
+  var template;
+  var actual;
+  var expected;
+
+  test.plan(10);
+
+  template = Handlebars.compile('{{math 1 "+" 2}}');
+  actual = template();
+  expected = '3';
+  test.equal(actual, expected, 'Works with +');
+
+  template = Handlebars.compile('{{math 2 "-" 1}}');
+  actual = template();
+  expected = '1';
+  test.equal(actual, expected, 'Works with -');
+
+  template = Handlebars.compile('{{math 2 "*" 3}}');
+  actual = template();
+  expected = '6';
+  test.equal(actual, expected, 'Works with *');
+
+  template = Handlebars.compile('{{math 9 "/" 3}}');
+  actual = template();
+  expected = '3';
+  test.equal(actual, expected, 'Works with /');
+
+  template = Handlebars.compile('{{math 17 "%" 3}}');
+  actual = template();
+  expected = '2';
+  test.equal(actual, expected, 'Works with %');
+
+  template = Handlebars.compile('{{math 1 "++"}}');
+  actual = template();
+  expected = '2';
+  test.equal(actual, expected, 'Works with ++');
+
+  template = Handlebars.compile('{{math 2 "--"}}');
+  actual = template();
+  expected = '1';
+  test.equal(actual, expected, 'Works with --');
+
+  template = Handlebars.compile('{{math 1 "++" 2}}');
+  actual = template();
+  expected = '2';
+  test.equal(actual, expected, 'Disregards extra arguments');
+
+  template = Handlebars.compile('{{math 1 "foo" 2}}');
+  test.throws(
+    function () {
+      template();
+    },
+    /needs a valid operator\.$/,
+    'Errors with an invalid operator'
+  );
+
+  template = Handlebars.compile('{{math}}');
+  test.throws(
+    function () {
+      template();
+    },
+    /needs two arguments\.$/,
+    'Errors with too few arguments'
+  );
+});

--- a/test/math.spec.js
+++ b/test/math.spec.js
@@ -11,7 +11,7 @@ tape('math', function (test) {
   var actual;
   var expected;
 
-  test.plan(10);
+  test.plan(11);
 
   template = Handlebars.compile('{{math 1 "+" 2}}');
   actual = template();
@@ -37,6 +37,11 @@ tape('math', function (test) {
   actual = template();
   expected = '2';
   test.equal(actual, expected, 'Works with %');
+
+  template = Handlebars.compile('{{math 2 "**" 3}}');
+  actual = template();
+  expected = '8';
+  test.equal(actual, expected, 'Works with **');
 
   template = Handlebars.compile('{{math 1 "++"}}');
   actual = template();


### PR DESCRIPTION
While working on the Cloud Four redesign, I had a use-case for being able to check against the current `@count` or `@index` incremented by one. I decided that I liked the pattern we adopted for `{{#compare}}` (where similar operations are handled by a single helper based on a provided operator), so I decided to do something similar for a `{{math}}` helper.

See source comments for more info and examples.

---

@erikjung @mrgerardorodriguez 