### PR TITLE
Add inline SVG helper

### DIFF
--- a/lib/svg.js
+++ b/lib/svg.js
@@ -1,0 +1,88 @@
+'use strict';
+
+var R = require('ramda');
+var ltx = require('ltx');
+var Handlebars = require('handlebars');
+var fs = require('fs');
+var path = require('path');
+
+function createSvgHelper (settings) {
+  var cache = {};
+
+  settings = R.merge({
+    basePath: process.cwd(),
+    extName: '.svg',
+    omitAttr: ['xmlns', 'xmlns:xlink'],
+  }, settings || {});
+
+  return function svg (name, options) {
+    var svg;
+
+    if (arguments.length < 2) {
+      throw new Error('The "svg" helper requires a file path.');
+    }
+
+    if (path.extname(name) === '') {
+      name += settings.extName;
+    }
+
+    name = path.join(settings.basePath, name);
+
+    if (!cache[name]) {
+      cache[name] = fs.readFileSync(name, 'utf-8');
+    }
+
+    svg = ltx.parse(cache[name]);
+
+    if (svg.name !== 'svg') {
+      throw new TypeError('The "svg" helper only supports SVG files.');
+    }
+
+    svg.attrs = R.pipe(
+      R.omit(settings.omitAttr),
+      R.merge(R.__, options.hash)
+    )(svg.attrs);
+
+    return new Handlebars.SafeString(svg.root());
+  }
+}
+
+/**
+ * Returns the contents of the SVG at the specified path, with any attributes
+ * passed along via the hash included on the root element.
+ *
+ * Inspired by https://github.com/aredridel/npm-handlebars-helper-svg
+ *
+ * @since v0.6.0
+ * @param {String} name - The path to the SVG. The extension may be omitted.
+ * @param {Object} options
+ * @return {String}
+ * @example
+ *
+ *   {{svg "foo/test.svg"}}
+ *
+ *   {{svg "foo/test"}}
+ *
+ *   {{svg "foo/test" class="foo" width="24" height="24"}}
+ */
+
+module.exports = createSvgHelper();
+
+/**
+ * Returns a new instance of the svg helper with settings applied. Useful for
+ * defining a base path for the project so you don't have to specify it for
+ * every usage of the helper.
+ *
+ * @since v0.6.0
+ * @param {Object} [settings]
+ * @param {String} [settings.basePath] - Base path for file lookups.
+ * @param {String} [settings.extName] - Extension to use when it is omitted.
+ * @param {Array} [settings.omitAttr] - Attributes to strip from the SVG root element.
+ * @example
+ *
+ *   var svgHelper = require('path/to/module').create({
+ *     basePath: './src/assets/images'
+ *   });
+ */
+
+module.exports.create = createSvgHelper;

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -6,9 +6,13 @@ var Handlebars = require('handlebars');
 var fs = require('fs');
 var path = require('path');
 
-function createSvgHelper (settings) {
-  var cache = {};
+var readAndCache = R.memoize(function (name) {
+  return fs.readFileSync(name, 'utf-8');
+});
 
+var pathToSvg = R.pipe(readAndCache, ltx.parse);
+
+function createSvgHelper (settings) {
   settings = R.merge({
     basePath: process.cwd(),
     extName: '.svg',
@@ -27,12 +31,7 @@ function createSvgHelper (settings) {
     }
 
     name = path.join(settings.basePath, name);
-
-    if (!cache[name]) {
-      cache[name] = fs.readFileSync(name, 'utf-8');
-    }
-
-    svg = ltx.parse(cache[name]);
+    svg = pathToSvg(name);
 
     if (svg.name !== 'svg') {
       throw new TypeError('The "svg" helper only supports SVG files.');

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -13,7 +13,7 @@ function createSvgHelper (settings) {
     basePath: process.cwd(),
     extName: '.svg',
     omitAttr: ['xmlns', 'xmlns:xlink'],
-  }, settings || {});
+  }, settings);
 
   return function svg (name, options) {
     var svg;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "core-hbs-helpers",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Handlebars helpers that we usually need.",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "capitalize": "^1.0.0",
     "chance": "^1.0.3",
     "handlebars": "^4.0.3",
+    "ltx": "^2.3.0",
     "moment": "^2.10.6",
     "num2fraction": "^1.2.2",
     "ramda": "^0.18.0",

--- a/test/fixtures/svg/test.html
+++ b/test/fixtures/svg/test.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html>
+</html>

--- a/test/fixtures/svg/test.svg
+++ b/test/fixtures/svg/test.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"><g/></svg>

--- a/test/svg.spec.js
+++ b/test/svg.spec.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var svg = require('../').svg;
+var tape = require('tape');
+var Handlebars = require('handlebars');
+var relativeSvg = svg.create({ basePath: './test/fixtures/svg' });
+
+Handlebars.registerHelper(svg.name, svg);
+Handlebars.registerHelper('relativeSvg', relativeSvg);
+
+tape('svg', function (test) {
+  var template;
+  var actual;
+  var expected = '<svg viewBox="0 0 1 1"><g/></svg>';
+
+  test.plan(7);
+
+  template = Handlebars.compile('{{svg "test/fixtures/svg/test.svg"}}');
+  actual = template();
+  test.equal(actual, expected, 'Works');
+
+  template = Handlebars.compile('{{svg "test/fixtures/svg/test"}}');
+  actual = template();
+  test.equal(actual, expected, 'Works with extension omitted');
+
+  template = Handlebars.compile('{{relativeSvg "test.svg"}}');
+  actual = template();
+  test.equal(actual, expected, 'Works with custom base path');
+
+  template = Handlebars.compile('{{svg "test/fixtures/svg/test" class="icon" width="10" height="10"}}');
+  actual = template();
+  expected = '<svg viewBox="0 0 1 1" height="10" width="10" class="icon"><g/></svg>';
+  test.equal(actual, expected, 'Works with attributes in hash');
+
+  template = Handlebars.compile('{{svg}}');
+  test.throws(
+    function () {
+      template();
+    },
+    /requires a file path\.$/,
+    'Errors when file path is omitted'
+  );
+
+  template = Handlebars.compile('{{svg "blah.svg"}}');
+  test.throws(
+    function () {
+      template();
+    },
+    /no such file or directory/,
+    'Errors when file does not exist'
+  );
+
+  template = Handlebars.compile('{{svg "test/fixtures/svg/test.html"}}');
+  test.throws(
+    function () {
+      template();
+    },
+    /only supports SVG files\.$/,
+    'Errors when path is not an SVG'
+  );
+});


### PR DESCRIPTION
This adds an `{{svg "path/to/file"}}` helper for easily including SVG icons and other goodies inline.

Differences from similar helpers:

- Although it will only include the `<svg>` (no proceeding definition info or anything like that) and will strip away `xmlns` attributes, it does not do any other optimization or modification of the SVG files.
- It does not cache its output to the file system at any point.
- It searches for files relative to the current process, with the option of setting a `basePath` prior to registering the helper to make things even more convenient.

See comments in source for more info.

---

@erikjung @mrgerardorodriguez @nicolemors 