### PR TITLE
Support prepended content in SVG helper

### DIFF
--- a/lib/svg.js
+++ b/lib/svg.js
@@ -44,7 +44,7 @@ function createSvgHelper (settings) {
     )(svg.attrs);
 
     if (!R.isNil(options.fn)) {
-      var prepend = ltx.parse('<root>' + options.fn(this) + '</root>');
+      prepend = ltx.parse('<root>' + options.fn(this) + '</root>');
       svg.children = R.concat(prepend.children, svg.children);
     }
 

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -21,6 +21,7 @@ function createSvgHelper (settings) {
 
   return function svg (name, options) {
     var svg;
+    var prepend;
 
     if (arguments.length < 2) {
       throw new Error('The "svg" helper requires a file path.');
@@ -41,6 +42,11 @@ function createSvgHelper (settings) {
       R.omit(settings.omitAttr),
       R.merge(R.__, options.hash)
     )(svg.attrs);
+
+    if (!R.isNil(options.fn)) {
+      var prepend = ltx.parse('<root>' + options.fn(this) + '</root>');
+      svg.children = R.concat(prepend.children, svg.children);
+    }
 
     return new Handlebars.SafeString(svg.root());
   }
@@ -63,6 +69,10 @@ function createSvgHelper (settings) {
  *   {{svg "foo/test"}}
  *
  *   {{svg "foo/test" class="foo" width="24" height="24"}}
+ *
+ *   {{#svg "foo/test" aria-labelledby="foo-title"}}
+ *     <title id="foo-title">Hello world</title>
+ *   {{/svg}}
  */
 
 module.exports = createSvgHelper();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudfour/hbs-helpers",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Handlebars helpers used for various Cloud Four projects.",
   "author": "Cloud Four (http://cloudfour.com)",
   "license": "MIT",

--- a/test/svg.spec.js
+++ b/test/svg.spec.js
@@ -13,7 +13,7 @@ tape('svg', function (test) {
   var actual;
   var expected = '<svg viewBox="0 0 1 1"><g/></svg>';
 
-  test.plan(7);
+  test.plan(8);
 
   template = Handlebars.compile('{{svg "test/fixtures/svg/test.svg"}}');
   actual = template();
@@ -31,6 +31,11 @@ tape('svg', function (test) {
   actual = template();
   expected = '<svg viewBox="0 0 1 1" height="10" width="10" class="icon"><g/></svg>';
   test.equal(actual, expected, 'Works with attributes in hash');
+
+  template = Handlebars.compile('{{#svg "test/fixtures/svg/test"}}<title>foo</title>{{/svg}}');
+  actual = template();
+  expected = '<svg viewBox="0 0 1 1"><title>foo</title><g/></svg>';
+  test.equal(actual, expected, 'Works with content');
 
   template = Handlebars.compile('{{svg}}');
   test.throws(


### PR DESCRIPTION
This PR adds the ability to use the existing `{{svg}}` helper as a block to prepend accessibility-related (or any other) content.

Previously, you could only use the helper like so:

```hbs
{{svg "foo/test" class="foo" width="24" height="24"}}
```

But what if you want to add a `<title>` attribute to the SVG contents itself? With this update, you can!

```hbs
{{#svg "foo/test" class="foo" width="24" height="24" aria-labelledby="foo-title"}}
  <title id="foo-title">foo</title>
{{/svg}}
```

Magic! 

---

@mrgerardorodriguez @saralohr 