### PR TITLE
Remove doctype from test.html fixture

### DIFF
--- a/test/fixtures/svg/test.html
+++ b/test/fixtures/svg/test.html
@@ -1,3 +1,2 @@
-<!doctype html>
 <html>
 </html>


### PR DESCRIPTION
`ltx` was complaining because the HTML5 doctype is not a valid XML element.

Fixes #46