### PR TITLE
Inline compare

### DIFF
--- a/lib/compare.js
+++ b/lib/compare.js
@@ -22,7 +22,7 @@ var operators = {
  * @param {String} operator
  * @param {*} right
  * @param {Object} options
- * @return {String} formatted html
+ * @return {(String|Boolean)} formatted html if block, true/false if inline
  * @example:
  * {{#compare 1 "<" 2}}
  *   This is true.

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -2,6 +2,18 @@
 
 var R = require('ramda');
 
+var operators = {
+  '==': R.equals,
+  '===': R.identical,
+  '!=': R.complement(R.equals),
+  '!==': R.complement(R.identical),
+  '<': R.lt,
+  '>': R.gt,
+  '<=': R.lte,
+  '>=': R.gte,
+  'typeof': R.type(R.__)
+};
+
 /**
  * Compare two values using logical operators.
  *
@@ -20,18 +32,8 @@ var R = require('ramda');
  */
 
 function compare (left, operator, right, options) {
-  var operators = {
-    '==': R.equals,
-    '===': R.identical,
-    '!=': R.complement(R.equals),
-    '!==': R.complement(R.identical),
-    '<': R.lt,
-    '>': R.gt,
-    '<=': R.lte,
-    '>=': R.gte,
-    'typeof': R.type(R.__)
-  };
-
+  var result;
+  
   if (arguments.length < 3) {
     throw new Error('The "compare" helper needs two arguments.');
   }
@@ -46,8 +48,13 @@ function compare (left, operator, right, options) {
     throw new Error('The "compare" helper needs a valid operator.')
   }
 
-  return operators[operator](left, right) ?
-    options.fn(this) : options.inverse(this);
+  result = operators[operator](left, right);
+  
+  if (R.isNil(options.fn)) {
+    return result;
+  }
+
+  return result ? options.fn(this) : options.inverse(this);
 };
 
 module.exports = compare;

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -29,6 +29,10 @@ var operators = {
  * {{else}}
  *   This is false.
  * {{/compare}}
+ *
+ * {{#if (compare 1 "<" 2)}}
+ *   Also works inline!
+ * {{/if}}
  */
 
 function compare (left, operator, right, options) {

--- a/test/compare.spec.js
+++ b/test/compare.spec.js
@@ -11,43 +11,79 @@ tape('compare', function (test) {
   var template;
   var actual;
 
-  test.plan(11);
+  test.plan(20);
 
   template = Handlebars.compile('{{#compare a "==" b}}✔︎{{/compare}}');
   actual = template({ a: true, b: true });
-  test.equal(actual, expected, 'Works with ==');
-
+  test.equal(actual, expected, 'Works as block with ==');
+  
   template = Handlebars.compile('{{#compare a "===" b}}✔︎{{/compare}}');
   actual = template({ a: true, b: true });
-  test.equal(actual, expected, 'Works with ===');
-
+  test.equal(actual, expected, 'Works as block with ===');
+  
   template = Handlebars.compile('{{#compare a "!=" b}}✔︎{{/compare}}');
   actual = template({ a: true, b: false });
-  test.equal(actual, expected, 'Works with !=');
-
+  test.equal(actual, expected, 'Works as block with !=');
+  
   template = Handlebars.compile('{{#compare a "!==" b}}✔︎{{/compare}}');
   actual = template({ a: true, b: 1 });
-  test.equal(actual, expected, 'Works with !==');
-
+  test.equal(actual, expected, 'Works as block with !==');
+  
   template = Handlebars.compile('{{#compare a "<" b}}✔︎{{/compare}}');
   actual = template({ a: 0, b: 1 });
-  test.equal(actual, expected, 'Works with <');
-
+  test.equal(actual, expected, 'Works as block with <');
+  
   template = Handlebars.compile('{{#compare a ">" b}}✔︎{{/compare}}');
   actual = template({ a: 1, b: 0 });
-  test.equal(actual, expected, 'Works with >');
-
+  test.equal(actual, expected, 'Works as block with >');
+  
   template = Handlebars.compile('{{#compare a "<=" b}}✔︎{{/compare}}');
   actual = template({ a: 0, b: 1 });
-  test.equal(actual, expected, 'Works with <=');
-
+  test.equal(actual, expected, 'Works as block with <=');
+  
   template = Handlebars.compile('{{#compare a ">=" b}}✔︎{{/compare}}');
   actual = template({ a: 1, b: 0 });
-  test.equal(actual, expected, 'Works with >=');
-
+  test.equal(actual, expected, 'Works as block with >=');
+  
   template = Handlebars.compile('{{#compare a "typeof" "Array"}}✔︎{{/compare}}');
   actual = template({ a: [] });
-  test.equal(actual, expected, 'Works with typeof');
+  test.equal(actual, expected, 'Works as block with typeof');
+  
+  template = Handlebars.compile('{{#if (compare a "==" b)}}✔︎{{/if}}');
+  actual = template({ a: true, b: true });
+  test.equal(actual, expected, 'Works inline with ==');
+  
+  template = Handlebars.compile('{{#if (compare a "===" b)}}✔︎{{/if}}');
+  actual = template({ a: true, b: true });
+  test.equal(actual, expected, 'Works inline with ===');
+  
+  template = Handlebars.compile('{{#if (compare a "!=" b)}}✔︎{{/if}}');
+  actual = template({ a: true, b: false });
+  test.equal(actual, expected, 'Works inline with !=');
+  
+  template = Handlebars.compile('{{#if (compare a "!==" b)}}✔︎{{/if}}');
+  actual = template({ a: true, b: 1 });
+  test.equal(actual, expected, 'Works inline with !==');
+  
+  template = Handlebars.compile('{{#if (compare a "<" b)}}✔︎{{/if}}');
+  actual = template({ a: 0, b: 1 });
+  test.equal(actual, expected, 'Works inline with <');
+  
+  template = Handlebars.compile('{{#if (compare a ">" b)}}✔︎{{/if}}');
+  actual = template({ a: 1, b: 0 });
+  test.equal(actual, expected, 'Works inline with >');
+  
+  template = Handlebars.compile('{{#if (compare a "<=" b)}}✔︎{{/if}}');
+  actual = template({ a: 0, b: 1 });
+  test.equal(actual, expected, 'Works inline with <=');
+  
+  template = Handlebars.compile('{{#if (compare a ">=" b)}}✔︎{{/if}}');
+  actual = template({ a: 1, b: 0 });
+  test.equal(actual, expected, 'Works inline with >=');
+  
+  template = Handlebars.compile('{{#if (compare a "typeof" "Array")}}✔︎{{/if}}');
+  actual = template({ a: [] });
+  test.equal(actual, expected, 'Works inline with typeof');
 
   template = Handlebars.compile('{{#compare a "foo" b}}✔︎{{/compare}}');
   test.throws(
@@ -57,7 +93,7 @@ tape('compare', function (test) {
     /needs a valid operator\.$/,
     'Errors with an invalid operator.'
   );
-
+  
   template = Handlebars.compile('{{#compare a}}✔︎{{/compare}}');
   test.throws(
     function () {


### PR DESCRIPTION
It would be helpful in our prototypes to be able to pass the results of `compare` to partials. This PR updates the existing helper to work either inline or as a block helper.

Before, we had to do things like this:

```handlebars
{{#each posts}}
  {{#compare @index "==" 0}}
    {{> post isFirst=true}}
  {{else}}
    {{> post}}
  {{/compare}}
{{/each}}
```

But with this change, we can do this instead:

```handlebars
{{#each posts}}
  {{> post isFirst=(compare @index "==" 0)}}
{{/each}}
```