### PR TITLE
all and any helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ gulp.task('default', function () {
 });
 ```
 
-## Documenation
+## Documentation
 
 See our [doxdox site](https://doxdox.org/cloudfour/core-hbs-helpers/) for complete documentation of each helper.

--- a/lib/all.js
+++ b/lib/all.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var R = require('ramda');
-
 /**
  * Output a block (or its inverse) based on whether or not all of the supplied
  * arguments are truthy.
@@ -24,17 +22,11 @@ var R = require('ramda');
  */
 
 function all() {
-  var values = R.dropLast(1, arguments);
-  var options = R.last(arguments);
-  var result = true;
-  var i;
-
-  for (i = 0; i < values.length; i++) {
-    if (!values[i]) {
-      result = false;
-      break;
-    }
-  }
+  var values = Array.prototype.slice.call(arguments);
+  var options = values.pop();
+  var result = values.every(function (value) {
+    return value;
+  });
 
   if (options.fn) {
     return result ? options.fn(this) : options.inverse(this);

--- a/lib/all.js
+++ b/lib/all.js
@@ -24,17 +24,10 @@ var R = require('ramda');
  */
 
 function all() {
+  var values = R.dropLast(1, arguments);
   var options = R.last(arguments);
   var result = true;
-  var values;
   var i;
-
-  if (R.isNil(options.fn)) {
-    options = undefined;
-    values = arguments;
-  } else {
-    values = R.dropLast(1, arguments);
-  }
 
   for (i = 0; i < values.length; i++) {
     if (!values[i]) {
@@ -43,7 +36,7 @@ function all() {
     }
   }
 
-  if (options) {
+  if (options.fn) {
     return result ? options.fn(this) : options.inverse(this);
   }
 

--- a/lib/all.js
+++ b/lib/all.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var R = require('ramda');
+
+/**
+ * Output a block (or its inverse) based on whether or not all of the supplied
+ * arguments are truthy.
+ *
+ * @since v0.11.0
+ * @param {...*} values One or more values to test against.
+ * @param {Object} options
+ * @return {String|Boolean}
+ * @example
+ * var a = true;
+ * var b = 1;
+ * var c = false;
+ *
+ * {{#all a b}}✔︎{{else}}✘{{/all}} //=> ✔︎
+ * {{#all b c}}✔︎{{else}}✘{{/all}} //=> ✘
+ * 
+ * {{#if (all a b)}}
+ *   Also works inline!
+ * {{/if}}
+ */
+
+function all() {
+  var options = R.last(arguments);
+  var result = true;
+  var values;
+  var i;
+
+  if (R.isNil(options.fn)) {
+    options = undefined;
+    values = arguments;
+  } else {
+    values = R.dropLast(1, arguments);
+  }
+
+  for (i = 0; i < values.length; i++) {
+    if (!values[i]) {
+      result = false;
+      break;
+    }
+  }
+
+  if (options) {
+    return result ? options.fn(this) : options.inverse(this);
+  }
+
+  return result;
+}
+
+module.exports = all;

--- a/lib/and.js
+++ b/lib/and.js
@@ -7,6 +7,7 @@ var R = require('ramda');
  * arguments are truthy.
  *
  * @since v0.0.1
+ * @deprecated Use the more flexible `all` helper instead.
  * @param {*} left
  * @param {*} right
  * @param {Object} options

--- a/lib/any.js
+++ b/lib/any.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var R = require('ramda');
+
+/**
+ * Output a block (or its inverse) based on whether or not any of the supplied
+ * arguments are truthy.
+ *
+ * @since v0.11.0
+ * @param {...*} values One or more values to test against.
+ * @param {Object} options
+ * @return {String|Boolean}
+ * @example
+ * var a = true;
+ * var b = 0;
+ * var c = false;
+ *
+ * {{#any a b}}✔︎{{else}}✘{{/all}} //=> ✔︎
+ * {{#any b c}}✔︎{{else}}✘{{/all}} //=> ✘
+ * 
+ * {{#if (any a b)}}
+ *   Also works inline!
+ * {{/if}}
+ */
+
+function any() {
+  var options = R.last(arguments);
+  var result = false;
+  var values;
+  var i;
+  
+  if (R.isNil(options.fn)) {
+    options = undefined;
+    values = arguments;
+  } else {
+    values = R.dropLast(1, arguments);
+  }
+  
+  for (i = 0; i < values.length; i++) {
+    if (values[i]) {
+      result = true;
+      break;
+    }
+  }
+  
+  if (options) {
+    return result ? options.fn(this) : options.inverse(this);
+  }
+  
+  return result;
+}
+
+module.exports = any;

--- a/lib/any.js
+++ b/lib/any.js
@@ -24,18 +24,11 @@ var R = require('ramda');
  */
 
 function any() {
+  var values = R.dropLast(1, arguments);
   var options = R.last(arguments);
   var result = false;
-  var values;
   var i;
-  
-  if (R.isNil(options.fn)) {
-    options = undefined;
-    values = arguments;
-  } else {
-    values = R.dropLast(1, arguments);
-  }
-  
+
   for (i = 0; i < values.length; i++) {
     if (values[i]) {
       result = true;
@@ -43,7 +36,7 @@ function any() {
     }
   }
   
-  if (options) {
+  if (options.fn) {
     return result ? options.fn(this) : options.inverse(this);
   }
   

--- a/lib/any.js
+++ b/lib/any.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var R = require('ramda');
-
 /**
  * Output a block (or its inverse) based on whether or not any of the supplied
  * arguments are truthy.
@@ -24,17 +22,11 @@ var R = require('ramda');
  */
 
 function any() {
-  var values = R.dropLast(1, arguments);
-  var options = R.last(arguments);
-  var result = false;
-  var i;
-
-  for (i = 0; i < values.length; i++) {
-    if (values[i]) {
-      result = true;
-      break;
-    }
-  }
+  var values = Array.prototype.slice.call(arguments);
+  var options = values.pop();
+  var result = values.some(function (value) {
+    return value;
+  });
   
   if (options.fn) {
     return result ? options.fn(this) : options.inverse(this);

--- a/lib/or.js
+++ b/lib/or.js
@@ -7,6 +7,7 @@ var R = require('ramda');
  * arguments are truthy.
  *
  * @since v0.0.1
+ * @deprecated Use the more flexible `any` helper instead.
  * @param {*} left
  * @param {*} right
  * @param {Object} options

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -6,7 +6,7 @@ var Handlebars = require('handlebars');
 var fs = require('fs');
 var path = require('path');
 
-var readAndCache = R.memoize(function (name) {
+var readAndCache = R.memoizeWith(R.identity, function (name) {
   return fs.readFileSync(name, 'utf-8');
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudfour/hbs-helpers",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Handlebars helpers used for various Cloud Four projects.",
   "author": "Cloud Four (http://cloudfour.com)",
   "license": "MIT",

--- a/test/all.spec.js
+++ b/test/all.spec.js
@@ -11,15 +11,23 @@ tape('all', function (test) {
   var template;
   var actual;
 
-  test.plan(3);
+  test.plan(5);
 
   template = Handlebars.compile('{{#all a b c}}✔︎{{/all}}');
   actual = template({ a: true, b: true, c: true });
   test.equal(actual, expected, 'Resolves to true when all values are true');
 
+  template = Handlebars.compile('{{#all a b c d e f g}}✔︎{{/all}}');
+  actual = template({ a: true, b: 14, c: 'false', d: {}, e: [], f: '0', g: -42 });
+  test.equal(actual, expected, 'Resolves to true when all values are truthy');
+
   template = Handlebars.compile('{{#all a b c}}{{else}}✔︎{{/all}}');
   actual = template({ a: true, b: false, c: true });
   test.equal(actual, expected, 'Resolves to false when any value is false');
+
+  template = Handlebars.compile('{{#all a b c}}{{else}}✔︎{{/all}}');
+  actual = template({ a: true, b: undefined, c: true });
+  test.equal(actual, expected, 'Resolves to false when any value is falsy');
 
   template = Handlebars.compile('{{#if (all a b c)}}✔︎{{/if}}');
   actual = template({ a: true, b: true, c: true });

--- a/test/all.spec.js
+++ b/test/all.spec.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var all = require('../').all;
+var tape = require('tape');
+var Handlebars = require('handlebars');
+
+Handlebars.registerHelper(all.name, all);
+
+tape('all', function (test) {
+  var expected = '✔︎';
+  var template;
+  var actual;
+
+  test.plan(3);
+
+  template = Handlebars.compile('{{#all a b c}}✔︎{{/all}}');
+  actual = template({ a: true, b: true, c: true });
+  test.equal(actual, expected, 'Resolves to true when all values are true');
+
+  template = Handlebars.compile('{{#all a b c}}{{else}}✔︎{{/all}}');
+  actual = template({ a: true, b: false, c: true });
+  test.equal(actual, expected, 'Resolves to false when any value is false');
+
+  template = Handlebars.compile('{{#if (all a b c)}}✔︎{{/if}}');
+  actual = template({ a: true, b: true, c: true });
+  test.equal(actual, expected, 'Works as an inline helper');
+});

--- a/test/any.spec.js
+++ b/test/any.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var any = require('../').any;
+var tape = require('tape');
+var Handlebars = require('handlebars');
+
+Handlebars.registerHelper(any.name, any);
+
+tape('any', function (test) {
+  var expected = '✔︎';
+  var template;
+  var actual;
+
+  test.plan(4);
+
+  template = Handlebars.compile('{{#any a b c}}✔︎{{/any}}');
+  actual = template({ a: true, b: true, c: true });
+  test.equal(actual, expected, 'Resolves to true when all values are true');
+
+  template = Handlebars.compile('{{#any a b c}}✔︎{{/any}}');
+  actual = template({ a: false, b: true, c: false });
+  test.equal(actual, expected, 'Resolves to true when any value is true');
+
+  template = Handlebars.compile('{{#any a b c}}{{else}}✔︎{{/any}}');
+  actual = template({ a: false, b: false, c: false });
+  test.equal(actual, expected, 'Resolves to false when no value is true');
+
+  template = Handlebars.compile('{{#if (any a b c)}}✔︎{{/if}}');
+  actual = template({ a: false, b: true, c: false });
+  test.equal(actual, expected, 'Works as an inline helper');
+});

--- a/test/any.spec.js
+++ b/test/any.spec.js
@@ -11,19 +11,31 @@ tape('any', function (test) {
   var template;
   var actual;
 
-  test.plan(4);
+  test.plan(7);
 
   template = Handlebars.compile('{{#any a b c}}✔︎{{/any}}');
   actual = template({ a: true, b: true, c: true });
   test.equal(actual, expected, 'Resolves to true when all values are true');
 
+  template = Handlebars.compile('{{#any a b c d e f g}}✔︎{{/any}}');
+  actual = template({ a: true, b: 14, c: 'false', d: {}, e: [], f: '0', g: -42 });
+  test.equal(actual, expected, 'Resolves to true when all values are truthy');
+
   template = Handlebars.compile('{{#any a b c}}✔︎{{/any}}');
   actual = template({ a: false, b: true, c: false });
   test.equal(actual, expected, 'Resolves to true when any value is true');
 
+  template = Handlebars.compile('{{#any a b c}}✔︎{{/any}}');
+  actual = template({ a: false, b: 14, c: false });
+  test.equal(actual, expected, 'Resolves to true when any value is truthy');
+
   template = Handlebars.compile('{{#any a b c}}{{else}}✔︎{{/any}}');
   actual = template({ a: false, b: false, c: false });
   test.equal(actual, expected, 'Resolves to false when no value is true');
+
+  template = Handlebars.compile('{{#any a b c}}{{else}}✔︎{{/any}}');
+  actual = template({ a: false, b: undefined, c: false });
+  test.equal(actual, expected, 'Resolves to false when no value is truthy');
 
   template = Handlebars.compile('{{#if (any a b c)}}✔︎{{/if}}');
   actual = template({ a: false, b: true, c: false });


### PR DESCRIPTION
In a recent project, I needed to be able to test whether _any_ of three properties were truthy. Currently, our `or` helpers only allow for two. And it can only be used as a block helper, so I couldn't do something like `{{#or firstProp (or secondProp thirdProp)}}`.

This adds `all` and `any` helpers as successors to `and` and `or`. They also support being used as block or inline helpers, so they can be combined in a single call or passed along as a property.

It also updates a function in `svg` that seems to have been broken by a previous Ramda version bump.

---

Closes #53