### PR TITLE
Add join helper

### DIFF
--- a/lib/join.js
+++ b/lib/join.js
@@ -1,0 +1,58 @@
+'use strict';
+
+var R = require('ramda');
+
+var defaults = {
+  separator: ', ',
+  lastSeparator: false
+};
+
+/**
+ * Output a string by concatening all the items in an array separated by commas
+ * or an optional custom separator. Final separator may be customized as well.
+ *
+ * @since v0.12.0
+ * @param {Array} list
+ * @param {String} [options.hash.separator=", "]
+ * @param {String} [options.hash.lastSeparator] Optional different separator to
+ * use before the last item in the array.
+ * @return string
+ * @example
+ * var items = ["a", "b", "c", "d"];
+ * {{join items}} //=> a, b, c, d
+ * {{join items separator="; "}} // => a; b; c; d
+ * {{join items lastSeparator=" and "}} //=> a, b, c and d
+ */
+
+function join (list, options) {
+  if (!Array.isArray(list) || list.length < 1) {
+    return '';
+  }
+
+  if (list.length === 1) {
+    return list[0];
+  }
+
+  var settings = R.merge(defaults, options.hash);
+  var items = list;
+  var lastItem;
+
+  if (!R.is(String, settings.separator)) {
+    settings.separator = defaults.separator;
+  }
+
+  if (R.is(String, settings.lastSeparator)) {
+    lastItem = R.last(items);
+    items = R.dropLast(1, items);
+  }
+
+  var result = items.join(settings.separator);
+
+  if (lastItem) {
+    result = [result, lastItem].join(settings.lastSeparator);
+  }
+
+  return result;
+}
+
+module.exports = join;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudfour/hbs-helpers",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Handlebars helpers used for various Cloud Four projects.",
   "author": "Cloud Four (http://cloudfour.com)",
   "license": "MIT",

--- a/test/join.spec.js
+++ b/test/join.spec.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var join = require('../').join;
+var tape = require('tape');
+var Handlebars = require('handlebars');
+
+Handlebars.registerHelper(join.name, join);
+
+tape('join', function (test) {
+  var items = ['a', 'b', 'c', 'd'];
+  var template;
+  var actual;
+  var expected;
+
+  test.plan(9);
+
+  template = Handlebars.compile('{{join items}}');
+  actual = template({ items: items });
+  expected = 'a, b, c, d';
+  test.equal(actual, expected, 'Works with default separator');
+
+  template = Handlebars.compile('{{join items separator="!"}}');
+  actual = template({ items: items });
+  expected = 'a!b!c!d';
+  test.equal(actual, expected, 'Works with custom separator');
+
+  template = Handlebars.compile('{{join items lastSeparator=" and "}}');
+  actual = template({ items: items });
+  expected = 'a, b, c and d';
+  test.equal(actual, expected, 'Works with custom last separator');
+
+  template = Handlebars.compile('{{{join items separator="+" lastSeparator="="}}}');
+  actual = template({ items: items });
+  expected = 'a+b+c=d';
+  test.equal(actual, expected, 'Works with custom normal and last separators');
+
+  template = Handlebars.compile('{{join items separator=42 lastSeparator=true}}');
+  actual = template({ items: items });
+  expected = 'a, b, c, d';
+  test.equal(actual, expected, 'Ignores non-string separators');
+
+  template = Handlebars.compile('{{join}}');
+  actual = template();
+  expected = '';
+  test.equal(actual, expected, 'Outputs nothing if list is omitted');
+
+  template = Handlebars.compile('{{join items}}');
+  actual = template({ items: [] });
+  expected = '';
+  test.equal(actual, expected, 'Outputs nothing if list is empty');
+
+  template = Handlebars.compile('{{join 42}}');
+  actual = template();
+  expected = '';
+  test.equal(actual, expected, 'Outputs nothing if argument is not a list');
+
+  template = Handlebars.compile('{{join items}}');
+  actual = template({ items: ['a'] });
+  expected = 'a';
+  test.equal(actual, expected, 'Inserts no separators for lists of one item');
+});


### PR DESCRIPTION
In a recent project, we had reason to include a helper for creating grammatical lists from arrays.

```js
// Input:
var items = ['a', 'b', 'c', d'];

// Output:
// a, b, c and d
```

I realized that it might be helpful if this functionality were generalized a bit, so it was more like an enhanced version of `Array.prototype.join`:

```handlebars
{{join items}}                        a, b, c, d
{{join items separator="; "}}         a; b; c; d
{{join items lastSeparator=" and "}}  a, b, c and d
```