### PR TITLE
Close test coverage gaps in and/or/compare/maybe/timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,162 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Note that while the version stays below `1.0.0`, the **minor** number carries
+breaking changes — `^0.11.0` will not pick up `0.12.0`.
+
+Everything below `Unreleased` was reconstructed after the fact from git history,
+release tags, and the `@since` annotations in `lib/`. Those entries record which
+helpers arrived in which release rather than every change each one contained, and
+releases before `0.6.1` predate this package's move to the `@cloudfour` scope, so
+they are not on npm under its current name. `0.9.0` and `0.10.0` were published
+but never tagged, so their links point at the version-bump commits instead.
+
+## [Unreleased]
+
+### Fixed
+
+- **Breaking.** `compare`'s `typeof` operator ignored its right operand
+  entirely. `R.type` takes one argument, so the `R.type(R.__)` it was built from
+  was not a partial application waiting on a second value — it was a function
+  that returned the type name of the left operand and discarded the right one.
+  Because any non-empty type name is truthy, the block always rendered:
+
+  ```hbs
+  {{#compare items "typeof" "Number"}}✔︎{{else}}✘{{/compare}}
+  ```
+
+  With `items` an Array, that produced `✔︎`. It now produces `✘`. Templates
+  whose type checks were wrong rendered anyway and will now take the `{{else}}`
+  branch. Used inline, `{{compare items "typeof" "Array"}}` returned the string
+  `"Array"` and now returns a boolean, so it can no longer be used to print the
+  type of a value.
+
+### Changed
+
+- Test coverage for `and`, `or`, `compare`, and `maybe` now exercises the
+  inverse (`{{else}}`) branch of each helper, which nothing had asserted before.
+  `maybe` forces both outcomes through a stubbed `Math.random` rather than
+  accepting either, and `timestamp` checks its non-UTC offset against fixed
+  values under an explicitly non-UTC timezone, which CI never exercised.
+
+## [0.11.0] - 2019-07-30
+
+### Added
+
+- `all` and `any` helpers, which accept any number of values and work both as
+  block helpers and inline.
+
+### Deprecated
+
+- `and` and `or`, in favor of `all` and `any`.
+
+## [0.10.0] - 2019-03-29
+
+### Added
+
+- `split` helper, returning an array that can be iterated over.
+- `replaceAll` helper.
+
+## [0.9.0] - 2017-01-11
+
+### Changed
+
+- `compare` works as an inline helper, returning `true`/`false` when used as a
+  subexpression instead of only rendering a block.
+
+## [0.8.0] - 2016-08-23
+
+### Added
+
+- `concat` helper.
+
+## [0.7.0] - 2016-06-29
+
+### Added
+
+- Block form of the `svg` helper, so content can be prepended inside the SVG
+  root element.
+
+## [0.6.1] - 2016-06-08
+
+### Changed
+
+- Published as `@cloudfour/hbs-helpers`. This is the earliest release available
+  on npm under that name.
+
+## [0.6.0] - 2016-05-25
+
+### Added
+
+- `svg` helper, inlining an SVG file's contents with attributes from the hash.
+
+## [0.5.0] - 2016-05-16
+
+### Added
+
+- `math` helper, including the exponentiation operator `**`.
+
+## [0.4.0] - 2016-05-06
+
+### Added
+
+- `capitalize` and `capitalizeWords` helpers.
+- `random` helper, backed by [Chance.js](https://chancejs.com).
+
+### Changed
+
+- The previous `random` helper was renamed to `randomItem` to make room for the
+  Chance-backed one.
+
+## [0.3.1] - 2016-04-29
+
+### Changed
+
+- Documentation for `dummyImgSrc`.
+
+## [0.3.0] - 2016-04-28
+
+### Added
+
+- `dummyImgSrc` helper, returning a data URI for a placeholder image.
+
+## [0.2.0] - 2016-04-25
+
+### Changed
+
+- `defaultTo` accepts any number of values rather than exactly two.
+
+## [0.1.1] - 2016-04-21
+
+### Added
+
+- `iterate` helper.
+
+## [0.1] - 2015-11-16
+
+Initial release.
+
+### Added
+
+- `and`, `around`, `average`, `compare`, `defaultTo`, `maybe`, `or`,
+  `randomItem`, `timestamp`, `toFixed`, `toFraction`, `toJSON`, `toSlug`, and
+  `toTitle` helpers.
+
+[unreleased]: https://github.com/cloudfour/core-hbs-helpers/compare/0.11.0...HEAD
+[0.11.0]: https://github.com/cloudfour/core-hbs-helpers/compare/5d1f7e7...0.11.0
+[0.10.0]: https://github.com/cloudfour/core-hbs-helpers/compare/690688a...5d1f7e7
+[0.9.0]: https://github.com/cloudfour/core-hbs-helpers/compare/0.8.0...690688a
+[0.8.0]: https://github.com/cloudfour/core-hbs-helpers/compare/0.7.0...0.8.0
+[0.7.0]: https://github.com/cloudfour/core-hbs-helpers/compare/0.6.1...0.7.0
+[0.6.1]: https://github.com/cloudfour/core-hbs-helpers/compare/v0.6.0...0.6.1
+[0.6.0]: https://github.com/cloudfour/core-hbs-helpers/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/cloudfour/core-hbs-helpers/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/cloudfour/core-hbs-helpers/compare/v0.3.1...v0.4.0
+[0.3.1]: https://github.com/cloudfour/core-hbs-helpers/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/cloudfour/core-hbs-helpers/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/cloudfour/core-hbs-helpers/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/cloudfour/core-hbs-helpers/compare/v0.1...v0.1.1
+[0.1]: https://github.com/cloudfour/core-hbs-helpers/releases/tag/v0.1

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -11,7 +11,12 @@ var operators = {
   '>': R.gt,
   '<=': R.lte,
   '>=': R.gte,
-  'typeof': R.type(R.__)
+  // `R.type` is unary, so `R.type(R.__)` would be a unary function that ignores
+  // the right operand entirely and returns the type name of the left one --
+  // always truthy, so the block always rendered. Compare the names explicitly.
+  'typeof': function (left, right) {
+    return R.type(left) === right;
+  }
 };
 
 /**
@@ -33,6 +38,10 @@ var operators = {
  * {{#if (compare 1 "<" 2)}}
  *   Also works inline!
  * {{/if}}
+ *
+ * {{#compare items "typeof" "Array"}}
+ *   The "typeof" operator compares against a type name.
+ * {{/compare}}
  */
 
 function compare (left, operator, right, options) {

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   ],
   "main": "index.js",
   "files": [
-    "lib",
-    "index.js"
+    "CHANGELOG.md",
+    "index.js",
+    "lib"
   ],
   "dependencies": {
     "capitalize": "2.0.4",

--- a/test/and.spec.js
+++ b/test/and.spec.js
@@ -11,11 +11,25 @@ tape('and', function (test) {
   var template;
   var actual;
 
-  test.plan(2);
+  test.plan(6);
+
+  template = Handlebars.compile('{{#and a b}}✔︎{{else}}✘{{/and}}');
+
+  actual = template({ a: true, b: true });
+  test.equal(actual, expected, 'Outputs the block when both values are truthy');
+
+  actual = template({ a: 1, b: 'zero' });
+  test.equal(actual, expected, 'Outputs the block for non-Boolean truthy values');
+
+  actual = template({ a: true, b: false });
+  test.equal(actual, '✘', 'Outputs the inverse block when the right value is falsy');
+
+  actual = template({ a: false, b: true });
+  test.equal(actual, '✘', 'Outputs the inverse block when the left value is falsy');
 
   template = Handlebars.compile('{{#and a b}}✔︎{{/and}}');
-  actual = template({ a: true, b: true });
-  test.equal(actual, expected, 'Works');
+  actual = template({ a: true, b: false });
+  test.equal(actual, '', 'Outputs nothing when falsy and no inverse block is given');
 
   template = Handlebars.compile('{{#and a}}✔︎{{/and}}');
   test.throws(

--- a/test/compare.spec.js
+++ b/test/compare.spec.js
@@ -7,99 +7,110 @@ var Handlebars = require('handlebars');
 Handlebars.registerHelper(compare.name, compare);
 
 tape('compare', function (test) {
-  var expected = '✔︎';
-  var template;
-  var actual;
+  var match = '✔︎';
+  var noMatch = '✘';
+  var block;
+  var inline;
 
-  test.plan(20);
+  test.plan(42);
 
-  template = Handlebars.compile('{{#compare a "==" b}}✔︎{{/compare}}');
-  actual = template({ a: true, b: true });
-  test.equal(actual, expected, 'Works as block with ==');
-  
-  template = Handlebars.compile('{{#compare a "===" b}}✔︎{{/compare}}');
-  actual = template({ a: true, b: true });
-  test.equal(actual, expected, 'Works as block with ===');
-  
-  template = Handlebars.compile('{{#compare a "!=" b}}✔︎{{/compare}}');
-  actual = template({ a: true, b: false });
-  test.equal(actual, expected, 'Works as block with !=');
-  
-  template = Handlebars.compile('{{#compare a "!==" b}}✔︎{{/compare}}');
-  actual = template({ a: true, b: 1 });
-  test.equal(actual, expected, 'Works as block with !==');
-  
-  template = Handlebars.compile('{{#compare a "<" b}}✔︎{{/compare}}');
-  actual = template({ a: 0, b: 1 });
-  test.equal(actual, expected, 'Works as block with <');
-  
-  template = Handlebars.compile('{{#compare a ">" b}}✔︎{{/compare}}');
-  actual = template({ a: 1, b: 0 });
-  test.equal(actual, expected, 'Works as block with >');
-  
-  template = Handlebars.compile('{{#compare a "<=" b}}✔︎{{/compare}}');
-  actual = template({ a: 0, b: 1 });
-  test.equal(actual, expected, 'Works as block with <=');
-  
-  template = Handlebars.compile('{{#compare a ">=" b}}✔︎{{/compare}}');
-  actual = template({ a: 1, b: 0 });
-  test.equal(actual, expected, 'Works as block with >=');
-  
-  template = Handlebars.compile('{{#compare a "typeof" "Array"}}✔︎{{/compare}}');
-  actual = template({ a: [] });
-  test.equal(actual, expected, 'Works as block with typeof');
-  
-  template = Handlebars.compile('{{#if (compare a "==" b)}}✔︎{{/if}}');
-  actual = template({ a: true, b: true });
-  test.equal(actual, expected, 'Works inline with ==');
-  
-  template = Handlebars.compile('{{#if (compare a "===" b)}}✔︎{{/if}}');
-  actual = template({ a: true, b: true });
-  test.equal(actual, expected, 'Works inline with ===');
-  
-  template = Handlebars.compile('{{#if (compare a "!=" b)}}✔︎{{/if}}');
-  actual = template({ a: true, b: false });
-  test.equal(actual, expected, 'Works inline with !=');
-  
-  template = Handlebars.compile('{{#if (compare a "!==" b)}}✔︎{{/if}}');
-  actual = template({ a: true, b: 1 });
-  test.equal(actual, expected, 'Works inline with !==');
-  
-  template = Handlebars.compile('{{#if (compare a "<" b)}}✔︎{{/if}}');
-  actual = template({ a: 0, b: 1 });
-  test.equal(actual, expected, 'Works inline with <');
-  
-  template = Handlebars.compile('{{#if (compare a ">" b)}}✔︎{{/if}}');
-  actual = template({ a: 1, b: 0 });
-  test.equal(actual, expected, 'Works inline with >');
-  
-  template = Handlebars.compile('{{#if (compare a "<=" b)}}✔︎{{/if}}');
-  actual = template({ a: 0, b: 1 });
-  test.equal(actual, expected, 'Works inline with <=');
-  
-  template = Handlebars.compile('{{#if (compare a ">=" b)}}✔︎{{/if}}');
-  actual = template({ a: 1, b: 0 });
-  test.equal(actual, expected, 'Works inline with >=');
-  
-  template = Handlebars.compile('{{#if (compare a "typeof" "Array")}}✔︎{{/if}}');
-  actual = template({ a: [] });
-  test.equal(actual, expected, 'Works inline with typeof');
+  // Each operator is checked in both directions. A block helper that only ever
+  // gets its truthy case asserted will happily pass with `options.inverse`
+  // stubbed out, which is how these all went uncovered for so long.
 
-  template = Handlebars.compile('{{#compare a "foo" b}}✔︎{{/compare}}');
+  block = Handlebars.compile('{{#compare a "==" b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a "==" b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, true, true), match, 'Block == resolves to true');
+  test.equal(template(block, true, false), noMatch, 'Block == resolves to false');
+  test.equal(template(inline, true, true), match, 'Inline == resolves to true');
+  test.equal(template(inline, true, false), noMatch, 'Inline == resolves to false');
+
+  block = Handlebars.compile('{{#compare a "===" b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a "===" b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, true, true), match, 'Block === resolves to true');
+  test.equal(template(block, true, 1), noMatch, 'Block === resolves to false');
+  test.equal(template(inline, true, true), match, 'Inline === resolves to true');
+  test.equal(template(inline, true, 1), noMatch, 'Inline === resolves to false');
+
+  block = Handlebars.compile('{{#compare a "!=" b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a "!=" b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, true, false), match, 'Block != resolves to true');
+  test.equal(template(block, true, true), noMatch, 'Block != resolves to false');
+  test.equal(template(inline, true, false), match, 'Inline != resolves to true');
+  test.equal(template(inline, true, true), noMatch, 'Inline != resolves to false');
+
+  block = Handlebars.compile('{{#compare a "!==" b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a "!==" b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, true, 1), match, 'Block !== resolves to true');
+  test.equal(template(block, true, true), noMatch, 'Block !== resolves to false');
+  test.equal(template(inline, true, 1), match, 'Inline !== resolves to true');
+  test.equal(template(inline, true, true), noMatch, 'Inline !== resolves to false');
+
+  block = Handlebars.compile('{{#compare a "<" b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a "<" b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, 0, 1), match, 'Block < resolves to true');
+  test.equal(template(block, 1, 0), noMatch, 'Block < resolves to false');
+  test.equal(template(inline, 0, 1), match, 'Inline < resolves to true');
+  test.equal(template(inline, 1, 0), noMatch, 'Inline < resolves to false');
+
+  block = Handlebars.compile('{{#compare a ">" b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a ">" b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, 1, 0), match, 'Block > resolves to true');
+  test.equal(template(block, 0, 1), noMatch, 'Block > resolves to false');
+  test.equal(template(inline, 1, 0), match, 'Inline > resolves to true');
+  test.equal(template(inline, 0, 1), noMatch, 'Inline > resolves to false');
+
+  block = Handlebars.compile('{{#compare a "<=" b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a "<=" b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, 0, 1), match, 'Block <= resolves to true');
+  test.equal(template(block, 1, 0), noMatch, 'Block <= resolves to false');
+  test.equal(template(inline, 0, 1), match, 'Inline <= resolves to true');
+  test.equal(template(inline, 1, 0), noMatch, 'Inline <= resolves to false');
+
+  block = Handlebars.compile('{{#compare a ">=" b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a ">=" b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, 1, 0), match, 'Block >= resolves to true');
+  test.equal(template(block, 0, 1), noMatch, 'Block >= resolves to false');
+  test.equal(template(inline, 1, 0), match, 'Inline >= resolves to true');
+  test.equal(template(inline, 0, 1), noMatch, 'Inline >= resolves to false');
+
+  // The right operand is a type name, not a value. Asserting the mismatch here
+  // matters more than usual: this operator used to ignore the right operand
+  // altogether and match everything.
+  block = Handlebars.compile('{{#compare a "typeof" b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a "typeof" b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, [], 'Array'), match, 'Block typeof resolves to true');
+  test.equal(template(block, [], 'Number'), noMatch, 'Block typeof resolves to false');
+  test.equal(template(inline, [], 'Array'), match, 'Inline typeof resolves to true');
+  test.equal(template(inline, [], 'Number'), noMatch, 'Inline typeof resolves to false');
+
+  // Omitting the operator falls back to ===.
+  block = Handlebars.compile('{{#compare a b}}✔︎{{else}}✘{{/compare}}');
+  inline = Handlebars.compile('{{#if (compare a b)}}✔︎{{else}}✘{{/if}}');
+  test.equal(template(block, 'x', 'x'), match, 'Block defaults to === and resolves to true');
+  test.equal(template(block, 'x', 'y'), noMatch, 'Block defaults to === and resolves to false');
+  test.equal(template(inline, 'x', 'x'), match, 'Inline defaults to === and resolves to true');
+  test.equal(template(inline, 'x', 'y'), noMatch, 'Inline defaults to === and resolves to false');
+
+  block = Handlebars.compile('{{#compare a "foo" b}}✔︎{{/compare}}');
   test.throws(
     function () {
-      template({ a: 1, b: 2 });
+      template(block, 1, 2);
     },
     /needs a valid operator\.$/,
     'Errors with an invalid operator.'
   );
-  
-  template = Handlebars.compile('{{#compare a}}✔︎{{/compare}}');
+
+  block = Handlebars.compile('{{#compare a}}✔︎{{/compare}}');
   test.throws(
     function () {
-      template({ a: 1 });
+      block({ a: 1 });
     },
     /needs two arguments\.$/,
     'Errors with missing arguments.'
   );
 });
+
+function template (compiled, a, b) {
+  return compiled({ a: a, b: b });
+}

--- a/test/maybe.spec.js
+++ b/test/maybe.spec.js
@@ -10,9 +10,24 @@ tape('maybe', function (test) {
   var template = Handlebars.compile(
     '{{#maybe}}pass{{else}}fail{{/maybe}}'
   );
-  var result = template();
-  var isMatch = result.search(/(pass|fail)/) !== -1;
+  var realRandom = Math.random;
 
-  test.plan(1);
-  test.ok(isMatch, 'works');
+  test.plan(2);
+
+  // `maybe` is genuinely random, so each branch has to be forced to be checked
+  // at all. It rounds `Math.random()`, which makes 0.5 the lowest value that
+  // selects the primary block.
+  test.teardown(function () {
+    Math.random = realRandom;
+  });
+
+  Math.random = function () {
+    return 0.5;
+  };
+  test.equal(template(), 'pass', 'Outputs the block');
+
+  Math.random = function () {
+    return 0.49;
+  };
+  test.equal(template(), 'fail', 'Outputs the inverse block');
 });

--- a/test/or.spec.js
+++ b/test/or.spec.js
@@ -11,11 +11,25 @@ tape('or', function (test) {
   var template;
   var actual;
 
-  test.plan(2);
+  test.plan(6);
+
+  template = Handlebars.compile('{{#or a b}}✔︎{{else}}✘{{/or}}');
+
+  actual = template({ a: false, b: true });
+  test.equal(actual, expected, 'Outputs the block when the right value is truthy');
+
+  actual = template({ a: true, b: false });
+  test.equal(actual, expected, 'Outputs the block when the left value is truthy');
+
+  actual = template({ a: 0, b: 'zero' });
+  test.equal(actual, expected, 'Outputs the block for non-Boolean truthy values');
+
+  actual = template({ a: false, b: 0 });
+  test.equal(actual, '✘', 'Outputs the inverse block when both values are falsy');
 
   template = Handlebars.compile('{{#or a b}}✔︎{{/or}}');
-  actual = template({ a: false, b: true });
-  test.equal(actual, expected, 'Works');
+  actual = template({ a: false, b: 0 });
+  test.equal(actual, '', 'Outputs nothing when falsy and no inverse block is given');
 
   template = Handlebars.compile('{{#or a}}✔︎{{/or}}');
   test.throws(

--- a/test/timestamp.spec.js
+++ b/test/timestamp.spec.js
@@ -12,8 +12,13 @@ tape('timestamp', function (test) {
   var actual;
   var expected;
   var today = new Date();
+  var realTz = process.env.TZ;
 
-  test.plan(7);
+  test.plan(9);
+
+  test.teardown(function () {
+    setTimezone(realTz);
+  });
 
   template = Handlebars.compile('{{timestamp}}');
   test.ok(moment(template()).isValid(), 'Works');
@@ -38,23 +43,26 @@ tape('timestamp', function (test) {
   actual = template({ date: 'Oct 21 15' });
   test.equal(actual, expected, 'Works with custom input format');
 
+  // CI runners are UTC, so `utc=false` has to be exercised under an explicitly
+  // non-UTC zone or it proves nothing. Both zones below are chosen for having
+  // no daylight saving, which keeps the expected offsets fixed year-round.
+  // Expected values are hard-coded rather than recomputed, so that a shared
+  // misunderstanding of moment's `ZZ` format can't pass silently.
   template = Handlebars.compile('{{timestamp format="ZZ" utc=false}}');
-  expected = (function (date) {
-    var offset = today.getTimezoneOffset() / 0.6;
-    var result = '';
-    if (offset > 0) {
-      result += '-';
-      if (offset.toString().length < 4) {
-        result += '0';
-      }
-      result += offset;
-    } else if (offset === 0) {
-      result = '+0000'
-    }
-    return result;
-  })(today);
+
+  setTimezone('America/Phoenix');
   actual = template();
-  test.equal(actual, expected, 'Maintains timezone offset in non-UTC mode');
+  test.equal(actual, '-0700', 'Maintains a whole-hour timezone offset in non-UTC mode');
+
+  setTimezone('Asia/Kolkata');
+  actual = template();
+  test.equal(actual, '+0530', 'Maintains a half-hour timezone offset in non-UTC mode');
+
+  template = Handlebars.compile('{{timestamp format="ZZ"}}');
+  actual = template();
+  test.equal(actual, '+0000', 'Ignores the local timezone in the default UTC mode');
+
+  setTimezone(realTz);
 
   template = Handlebars.compile('{{timestamp date}}');
   test.throws(
@@ -65,3 +73,14 @@ tape('timestamp', function (test) {
     'Errors when passed an invalid date value'
   );
 });
+
+// Node re-reads `process.env.TZ` when the next Date is constructed, so the zone
+// can be swapped mid-run without spawning a child process.
+function setTimezone (tz) {
+  if (tz === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = tz;
+  }
+}
+


### PR DESCRIPTION
## Overview

Four helpers — `and`, `or`, `compare`, and `maybe` — pick between `options.fn(this)` and `options.inverse(this)`, but only the truthy path was ever asserted. Line coverage reported them as covered, because a line that executes still counts even when nothing would notice if it misbehaved. Mutating all six block helpers so the inverse branch is unreachable left 123 of 127 assertions passing. With this PR, the same mutation fails 20. That matters most for Renovate bumps: a regression in ramda's `R.and`/`R.or` that made them always return truthy would previously have sailed through CI.

Writing the mismatch case for `compare`'s `typeof` operator surfaced a real bug, so this PR fixes it too. `R.type` is unary, which means `R.type(R.__)` was not a partial application waiting on a second argument — it was a unary function that ignored the right operand entirely and returned the type name of the left one. Any non-empty type name is truthy, so `{{#compare a "typeof" "Number"}}` matched an Array, and the inline form returned the string `"Array"` instead of a boolean. The existing `typeof` assertion passed for the wrong reason. Two other assertions could not fail at all: `maybe`'s only check matched `/(pass|fail)/`, which is satisfied by either branch, and `timestamp`'s offset test recomputed the value it was checking and short-circuited to `'+0000'` whenever `getTimezoneOffset()` returned `0` — which is what happens on CI, since GitHub Actions runners are UTC. The `utc=false` path that test exists to protect never ran there.

Closes #193.

## Screenshots

## Testing

CI covers this one, since the deliverable is the test suite itself — but if you want to confirm the tests actually bite rather than just pass:

- [ ] Run `npm test` — 160 assertions should pass (up from 127)
- [ ] Run `TZ=UTC npm test` to imitate a CI runner — still 160 passing, and the two timezone-offset assertions should appear as passing rather than being skipped over
- [ ] Make the inverse branch unreachable: `perl -0pi -e 's/options\.inverse\(this\)/options.fn(this)/g' lib/{all,and,any,compare,or,maybe}.js`
- [ ] Run `npm test` — 20 assertions should now fail. On `main` the same mutation only fails 4. Restore with `git checkout -- lib/`
- [ ] Put the `typeof` bug back by changing `lib/compare.js` to `'typeof': R.type(R.__)`, then run `npm test` — the two "typeof resolves to false" assertions should fail. Restore with `git checkout -- lib/`

Behavior change worth a look during review: `{{#compare x "typeof" "Something"}}` used to render its block for *any* type name, and now only renders when the name matches. Anything relying on the old always-true behavior will change. Inline `{{compare x "typeof" "Array"}}` now returns a boolean instead of a type-name string.
