### PR TITLE
Use rest and default parameters in helper signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ but never tagged, so their links point at the version-bump commits instead.
 
 ### Changed
 
+- **Breaking.** `and`, `or`, and `compare` reject too many values, not just too
+  few. Arity was previously read from `arguments.length`, which could only ever
+  catch the missing case: one value too many landed in the parameter holding
+  Handlebars' options object, and the helper carried on with the wrong thing in
+  hand. `{{#and a b c}}` and `{{#or a b c}}` failed with `TypeError: options.fn
+  is not a function`, and `{{#compare a "==" b c}}` rendered the string `true`
+  into the template. All three now raise the helper's own error.
 - **Breaking.** `average`, `capitalize`, `capitalizeWords`, and `toFixed` throw
   `TypeError` instead of `Error` when handed the wrong type. `TypeError` is
   still an `instanceof Error`, so `try`/`catch` is unaffected; only code

--- a/lib/and.js
+++ b/lib/and.js
@@ -11,7 +11,7 @@ const R = require('ramda');
  * @param {any} left
  * @param {any} right
  * @param {object} options
- * @throws {Error} An error is thrown when the `right` argument is missing.
+ * @throws {Error} An error is thrown unless exactly two values are supplied.
  * @returns {string}
  * @example
  * var a = true;
@@ -22,10 +22,15 @@ const R = require('ramda');
  * {{#and b c}}✔︎{{else}}✘{{/and}} //=> ✘
  */
 
-function and (left, right, options) {
-  if (arguments.length < 3) {
+function and (...args) {
+  const options = args.pop();
+
+  if (args.length !== 2) {
     throw new Error('The "and" helper needs two arguments.');
   }
+
+  const [left, right] = args;
+
   return R.and(left, right) ?
     options.fn(this) : options.inverse(this);
 }

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -44,16 +44,18 @@ const operators = {
  * {{/compare}}
  */
 
-function compare (left, operator, right, options) {
-  if (arguments.length < 3) {
+function compare (...args) {
+  const options = args.pop();
+
+  if (args.length < 2 || args.length > 3) {
     throw new Error('The "compare" helper needs two arguments.');
   }
 
-  if (options === undefined) {
-    options = right;
-    right = operator;
-    operator = '===';
-  }
+  // The operator may be omitted, in which case the values are compared for
+  // identity: `{{#compare a b}}`.
+  const [left, operator, right] = args.length === 2
+    ? [args[0], '===', args[1]]
+    : args;
 
   if (operators[operator] === undefined) {
     throw new Error('The "compare" helper needs a valid operator.')

--- a/lib/math.js
+++ b/lib/math.js
@@ -32,24 +32,23 @@ const operators = {
  * {{math 2 "--"}} //=> 1
  */
 
-function math (left, operator, right, options) {
-  if (arguments.length < 3) {
+function math (...args) {
+  // The last argument is always the Handlebars options object, which this
+  // helper has no use for.
+  const values = args.slice(0, -1);
+
+  if (values.length < 2) {
     throw new Error('The "math" helper needs at least two arguments.');
   }
 
-  if (options === undefined) {
-    options = right;
-    right = undefined;
-  }
-
-  left = Number.parseFloat(left);
-  right = Number.parseFloat(right);
+  // `right` is left undefined for the unary operators, `++` and `--`.
+  const [left, operator, right] = values;
 
   if (operators[operator] === undefined) {
     throw new Error ('The "math" helper needs a valid operator.');
   }
 
-  return operators[operator](left, right);
+  return operators[operator](Number.parseFloat(left), Number.parseFloat(right));
 }
 
 module.exports = math;

--- a/lib/or.js
+++ b/lib/or.js
@@ -11,7 +11,7 @@ const R = require('ramda');
  * @param {any} left
  * @param {any} right
  * @param {object} options
- * @throws {Error} An error is thrown when the `right` argument is missing.
+ * @throws {Error} An error is thrown unless exactly two values are supplied.
  * @returns {string}
  * @example
  * var a = true;
@@ -24,10 +24,15 @@ const R = require('ramda');
  * {{#or c d}}✔︎{{else}}✘{{/or}} //=> ✘
  */
 
-function or (left, right, options) {
-  if (arguments.length < 3) {
+function or (...args) {
+  const options = args.pop();
+
+  if (args.length !== 2) {
     throw new Error('The "or" helper needs two arguments.');
   }
+
+  const [left, right] = args;
+
   return R.or(left, right) ?
     options.fn(this) : options.inverse(this);
 }

--- a/lib/random.js
+++ b/lib/random.js
@@ -23,9 +23,9 @@ let chance;
  */
 
 function random (...args) {
-  const options = R.last(args);
+  const options = args.pop();
   const hash = options.hash || {};
-  const method = args.length > 1 ? args[0] : 'integer';
+  const [method = 'integer'] = args;
 
   if (!R.is(String, method)) {
     throw new Error('The "random" helper\'s first argument must be a String.');

--- a/lib/svg.js
+++ b/lib/svg.js
@@ -19,10 +19,14 @@ function createSvgHelper (settings) {
     omitAttr: ['xmlns', 'xmlns:xlink'],
   }, settings);
 
-  return function svg (name, options) {
-    if (arguments.length < 2) {
+  return function svg (...args) {
+    const options = args.pop();
+
+    if (args.length === 0) {
       throw new Error('The "svg" helper requires a file path.');
     }
+
+    let [name] = args;
 
     if (path.extname(name) === '') {
       name += settings.extName;

--- a/test/and.spec.js
+++ b/test/and.spec.js
@@ -12,7 +12,7 @@ tape('and', (test) => {
   let template;
   let actual;
 
-  test.plan(6);
+  test.plan(7);
 
   template = Handlebars.compile('{{#and a b}}✔︎{{else}}✘{{/and}}');
 
@@ -39,5 +39,14 @@ tape('and', (test) => {
     },
     /needs two arguments\.$/v,
     'Errors with missing arguments.'
+  );
+
+  template = Handlebars.compile('{{#and a b c}}✔︎{{/and}}');
+  test.throws(
+    () => {
+      template({ a: true, b: true, c: true })
+    },
+    /needs two arguments\.$/v,
+    'Errors with extra arguments.'
   );
 });

--- a/test/compare.spec.js
+++ b/test/compare.spec.js
@@ -13,7 +13,7 @@ tape('compare', (test) => {
   let block;
   let inline;
 
-  test.plan(42);
+  test.plan(43);
 
   // Each operator is checked in both directions. A block helper that only ever
   // gets its truthy case asserted will happily pass with `options.inverse`
@@ -109,6 +109,17 @@ tape('compare', (test) => {
     },
     /needs two arguments\.$/v,
     'Errors with missing arguments.'
+  );
+
+  // This used to slip past the arity check and render the string "true",
+  // because the fourth value was mistaken for the options object.
+  block = Handlebars.compile('{{#compare a "==" b c}}✔︎{{/compare}}');
+  test.throws(
+    () => {
+      block({ a: 1, b: 1, c: 1 });
+    },
+    /needs two arguments\.$/v,
+    'Errors with extra arguments.'
   );
 });
 

--- a/test/or.spec.js
+++ b/test/or.spec.js
@@ -12,7 +12,7 @@ tape('or', (test) => {
   let template;
   let actual;
 
-  test.plan(6);
+  test.plan(7);
 
   template = Handlebars.compile('{{#or a b}}✔︎{{else}}✘{{/or}}');
 
@@ -39,5 +39,14 @@ tape('or', (test) => {
     },
     /needs two arguments\.$/v,
     'Errors with missing arguments.'
+  );
+
+  template = Handlebars.compile('{{#or a b c}}✔︎{{/or}}');
+  test.throws(
+    () => {
+      template({ a: false, b: true, c: true })
+    },
+    /needs two arguments\.$/v,
+    'Errors with extra arguments.'
   );
 });


### PR DESCRIPTION
## Overview

Five helpers detected their arity by reading `arguments.length` and one picked a default that way. This replaces those with rest and default parameters — the half of #30 that `eslint --fix` can't do, because it changes how arity is *detected* rather than how the code reads.

The change has a consequence worth understanding, and it's the reason this needed doing rather than just deleting the `var`s. `arguments.length` could only ever catch *too few* values: with the options object arriving as a trailing argument, one value too many landed in the `options` parameter instead, and the helper carried on with the wrong thing in hand. Popping the options object off a rest parameter makes both directions detectable, and three cases that used to fall through now hit the existing error message:

```
{{#and a b c}}           was  TypeError: options.fn is not a function
{{#or a b c}}            was  TypeError: options.fn is not a function
{{#compare a "==" b c}}  silently rendered the string "true"
```

That last one is the one to look at — `compare` mistook the fourth value for its options object, found no `.fn` on it, decided it was being called inline, and returned a bare boolean into the template. Specs are added for all three. `math` still accepts extra arguments, since it documents "at least two" and already has a spec pinning that.

Three of the helpers named on the issue turned out not to need this. `average`, `capitalize`, and `dummyImgSrc` validate argument *types*, not counts, so rest parameters buy them nothing. `capitalize` is also the one helper here with no existing check that assumes a trailing options object, which means converting it would break direct, non-Handlebars calls — worth leaving alone.

Closes #30.

## Screenshots

## Testing

- [ ] In any project using these helpers, render `{{#compare 1 "==" 1 1}}` — before this change the page shows the word "true" where the block should be; now it raises "The compare helper needs two arguments."
- [ ] Render `{{#and a b c}}yes{{else}}no{{/and}}` with all three values set. Before, this failed with an opaque "options.fn is not a function"; now the message names the helper and the problem. Same for `{{#or a b c}}`.
- [ ] Confirm the normal forms are untouched: `{{#and a b}}`, `{{#or a b}}`, `{{#compare a "<" b}}`, the operator-less `{{#compare a b}}`, and the inline `{{#if (compare a "<" b)}}`.
- [ ] Confirm `{{random}}` still returns an integer and `{{random "state"}}` still returns a state — the default parameter replaced the branch that chose between them.
- [ ] Confirm `{{svg "some/file"}}` still resolves and injects, including the block form with content inside it.

One thing I'd like a second opinion on during review: erroring on too many arguments is a judgment call. The alternative was to ignore the extras silently. I went with the error because all three cases already failed today — two loudly but confusingly, one silently and wrongly — so this trades a crash for a clear message rather than trading a crash for quiet wrong output. If you'd rather `and`/`or`/`compare` shrug off extra values the way `math` does, it's a one-line change in each.

Sequencing note: this is stacked on #195 (issue #60), which is itself stacked on #194 (issue #193). Merge in that order.
