### PR TITLE
Stop Renovate managing engines.node

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,4 +1,12 @@
 {
   "extends": ["config:recommended", ":automergeMinor", ":pinVersions"],
-  "minimumReleaseAge": "3 days"
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "description": "engines.node states what consumers need, not what we develop on. Pinning or auto-bumping it silently drops support for everyone else. .nvmrc and the CI node-version are handled by other managers and still update.",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
## Overview

Renovate opened #199 to rewrite `engines.node` from `">=22.13.0"` to `"v26.8.0"`. That field states which Node versions the *published package* supports, so pinning it doesn't record what we build on — it declares that the package refuses every Node except 26.8.0 exactly. Consumers on anything else get `EBADENGINE`, or a failed install under `engine-strict`. Not even the next patch release qualifies:

| Node | vs `"v26.8.0"` | vs `">=22.13.0"` |
|---|---|---|
| 24.19.0 — what CI and `.nvmrc` use | ✘ | ✔︎ |
| 26.8.0 | ✔︎ | ✔︎ |
| 26.9.0 | ✘ | ✔︎ |

The package would have declared it doesn't support the only Node version it is ever tested against.

The cause is `:pinVersions` in `.renovaterc.json`, which is right for `dependencies` (this repo pins deliberately) and wrong for `engines`. It only started applying here because `engines` didn't exist until #195 added it. This disables Renovate for npm's `engines` depType — raising a supported-Node floor is a breaking change for consumers and belongs in a deliberate edit, not an automated bump. `.nvmrc` and the CI `node-version` are handled by different managers and keep updating as before.

Worth noting the near miss: `:automergeMinor` is enabled, so #199 would have merged unattended had CI passed. The lint step added in #195 an hour earlier is what caught it.

Closes #199.

## Screenshots

## Testing

Config changes only — nothing to exercise in the app, and CI covers lint and tests. If you want to verify the config itself:

- [ ] Run `npx --package renovate -- renovate-config-validator .renovaterc.json` — it should report "Config validated successfully"
- [ ] Confirm `package.json` still reads `"node": ">=22.13.0"` on this branch, i.e. #199's change is not being merged along with this
- [ ] After merge, watch that Renovate closes #199 on its next run and does not reopen an `engines` PR. Node updates to `.nvmrc` and `.github/workflows/ci.yml` should still appear normally — those are the ones we do want.
