### PR TITLE
Align the Renovate engines rule with our other repos

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,10 +3,8 @@
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {
-      "description": "engines.node states what consumers need, not what we develop on. Pinning or auto-bumping it silently drops support for everyone else. .nvmrc and the CI node-version are handled by other managers and still update.",
-      "matchManagers": ["npm"],
-      "matchDepTypes": ["engines"],
-      "enabled": false
+      "matchDepTypes": ["peerDependencies", "engines"],
+      "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
## Overview

#200 stopped Renovate pinning `engines.node`, but with a rule I wrote from scratch. Surveying the rest of the org afterwards turned up an existing convention for exactly this — `lighthouse-parade`, `eslint-config`, `stylelint-config-cloudfour`, and `stylelint-config-cloudfour-suit` all carry the same block, and have for a while:

```json
{
  "matchDepTypes": ["peerDependencies", "engines"],
  "rangeStrategy": "replace"
}
```

It's better than what #200 landed on two counts. It also covers `peerDependencies`, which have the same pinning hazard and which this package may well grow. And `rangeStrategy: "replace"` preserves the *shape* of the range rather than switching updates off entirely, so if the supported-Node floor ever genuinely needs raising, Renovate can still propose it — where `"enabled": false` would let the field quietly go stale instead.

This adopts the shared block verbatim, making the rule byte-identical across all five repos so a config diff between them stays clean.

That `core-hbs-helpers` was the only repo missing it is a sequencing artifact, not a gap in the convention: `engines` didn't exist here until #195 added it last week, well after the other repos settled on this.

## Screenshots

## Testing

Config-only; CI covers lint and tests.

- [ ] Run `npx --package renovate -- renovate-config-validator .renovaterc.json` — it should report "Config validated successfully"
- [ ] Compare against any of `cloudfour/eslint-config`, `cloudfour/stylelint-config-cloudfour`, or `cloudfour/lighthouse-parade` and confirm the `packageRules` entry matches theirs
- [ ] Over the next few Renovate runs, confirm no PR appears touching `engines.node`, while Node updates to `.nvmrc` and `.github/workflows/ci.yml` still arrive as normal
