### PR TITLE
Raise from capitalize and capitalizeWords when called with no value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ but never tagged, so their links point at the version-bump commits instead.
 
 ### Fixed
 
+- `{{capitalize}}` and `{{capitalizeWords}}` with no value rendered
+  `"[object object]"` instead of raising. Both documented an error for the
+  missing-argument case and both checked for it, but the check couldn't see it:
+  Handlebars appends its options object as a trailing argument, so with nothing
+  passed that object *was* the value — not nil, not a string, and duly
+  stringified. The named-but-undefined form, `{{capitalize missing}}`, always
+  raised correctly, which is the path the specs covered.
 - **Breaking.** `compare`'s `typeof` operator ignored its right operand
   entirely. `R.type` takes one argument, so the `R.type(R.__)` it was built from
   was not a partial application waiting on a second value — it was a function
@@ -36,6 +43,11 @@ but never tagged, so their links point at the version-bump commits instead.
 
 ### Changed
 
+- **Breaking.** `capitalize` and `capitalizeWords` are Handlebars-only. They now
+  read their value from the argument before the options object rather than the
+  first argument, so calling them directly — `helpers.capitalize('hi')` — raises
+  instead of returning `"Hi"`. Only registering them as Handlebars helpers was
+  ever documented, and `and`, `or`, and `compare` have always worked this way.
 - **Breaking.** `and`, `or`, and `compare` reject too many values, not just too
   few. Arity was previously read from `arguments.length`, which could only ever
   catch the missing case: one value too many landed in the parameter holding

--- a/lib/capitalize.js
+++ b/lib/capitalize.js
@@ -8,12 +8,19 @@ const R = require('ramda');
  *
  * @since 0.4.0
  * @param {string | *} str - String to capitalize. Other types will be converted.
+ * @param {object} options
  * @returns {string}
+ * @throws {TypeError} An error is thrown when no value is supplied.
  * @example
  * {{capitalize "hello world"}} //=> "Hello world"
  */
 
-function capitalize (str) {
+function capitalize (...args) {
+  // Handlebars always appends its options object, so the value to capitalize is
+  // the argument before it. Reading `args[0]` instead would mistake the options
+  // object for the value when the helper is called as bare `{{capitalize}}`.
+  let [str] = args.slice(0, -1);
+
   if (R.isNil(str)) {
     throw new TypeError('The "capitalize" helper requires one argument.')
   }

--- a/lib/capitalizeWords.js
+++ b/lib/capitalizeWords.js
@@ -9,14 +9,21 @@ const R = require('ramda');
  *
  * @since 0.4.0
  * @param {string | *} str - String to capitalize. Other types will be converted.
+ * @param {object} options
  * @returns {string}
+ * @throws {TypeError} An error is thrown when no value is supplied.
  * @example
  * {{capitalizeWords "hello world"}} //=> "Hello World"
  * {{capitalizeWords "hello-cañapolísas"}} //=> "Hello-Cañapolísas"
  * {{capitalizeWords "it's a nice day"}} //=> "It's A Nice Day"
  */
 
-function capitalizeWords (str) {
+function capitalizeWords (...args) {
+  // Handlebars always appends its options object, so the value to capitalize is
+  // the argument before it. Reading `args[0]` instead would mistake the options
+  // object for the value when the helper is called as bare `{{capitalizeWords}}`.
+  let [str] = args.slice(0, -1);
+
   if (R.isNil(str)) {
     throw new TypeError('The "capitalizeWords" helper requires one argument.')
   }

--- a/test/capitalize.spec.js
+++ b/test/capitalize.spec.js
@@ -12,7 +12,7 @@ tape('capitalize', (test) => {
   let expected;
   let actual;
 
-  test.plan(3);
+  test.plan(4);
 
   expected = 'Hello world';
   actual = template({ content: 'hello world' });
@@ -28,5 +28,16 @@ tape('capitalize', (test) => {
     },
     /requires one argument\.$/v,
     'Errors when argument is missing'
+  );
+
+  // `{{capitalize}}` with no value at all reaches a different path: Handlebars
+  // passes only its options object, which used to be stringified and
+  // capitalized into "[object Object]".
+  test.throws(
+    () => {
+      Handlebars.compile('{{capitalize}}')();
+    },
+    /requires one argument\.$/v,
+    'Errors when called with no arguments'
   );
 });

--- a/test/capitalizeWords.spec.js
+++ b/test/capitalizeWords.spec.js
@@ -12,7 +12,7 @@ tape('capitalizeWords', (test) => {
   let expected;
   let actual;
 
-  test.plan(3);
+  test.plan(4);
 
   expected = '"How\'s It Going?"';
   actual = template({ content: '"how\'s it going?"' });
@@ -28,5 +28,16 @@ tape('capitalizeWords', (test) => {
     },
     /requires one argument\.$/v,
     'Errors when argument is missing'
+  );
+
+  // `{{capitalizeWords}}` with no value at all reaches a different path: Handlebars
+  // passes only its options object, which used to be stringified and
+  // capitalized into "[object Object]".
+  test.throws(
+    () => {
+      Handlebars.compile('{{capitalizeWords}}')();
+    },
+    /requires one argument\.$/v,
+    'Errors when called with no arguments'
   );
 });


### PR DESCRIPTION
## Overview

`capitalize` and `capitalizeWords` both document an error for the missing-argument case, and both have a check for it. The check couldn't see the case it was written for. Handlebars appends its options object as a trailing argument, so with no value passed that object *was* `str` — not nil, not a String, and duly stringified:

```
{{capitalize}}       →  "[object object]"
{{capitalizeWords}}  →  "[Object Object]"
```

Reading the value from the argument *before* the options object fixes it. Per the discussion on #197 this takes the first of the three options: accept that these helpers are Handlebars-only. The alternative — duck-typing the options object the way `timestamp` does — was rejected because `.hash` is an ordinary property name, so any value carrying one (a parsed URL, a git commit record, an asset manifest entry) would be mistaken for the options object and rejected as "no argument" when an argument was plainly passed. That trades a cosmetic bug for a misleading error on legitimate data.

The cost is that calling these directly, `helpers.capitalize('hi')`, now raises instead of returning `"Hi"`. That's a real break, but a narrow one: registering the helpers with Handlebars is the only usage the README documents, and `and`, `or`, and `compare` have always assumed a trailing options object, so the package already didn't support direct calls in general.

Closes #197.

## Screenshots

## Testing

CI covers this, but the interesting part is *why* the existing tests missed it — worth confirming by hand:

- [ ] On `main`, render `{{capitalize}}` with no value. It produces the string `[object object]`. On this branch it raises "The capitalize helper requires one argument."
- [ ] Confirm the normal forms are untouched: `{{capitalize "hello world"}}` → `Hello world`, and `{{capitalizeWords "it's a nice day"}}` → `It's A Nice Day`
- [ ] Confirm non-string values still convert rather than raising — `{{capitalize true}}` → `True`, and `{{capitalizeWords}}` over an array → `A,B,C`
- [ ] Render `{{capitalize obj}}` where `obj` has a `hash` property. It should still stringify to `[object object]`, not raise — this is the case the rejected option would have broken
- [ ] Check out this branch, revert just `lib/`, and run `npm test` — the two new "Errors when called with no arguments" assertions should fail. The pre-existing "Errors when argument is missing" assertions pass either way, since they exercise a named-but-undefined value rather than a bare call

If anything in your projects calls these helpers as plain functions rather than through Handlebars, that will now raise — worth a grep before merging.
