### PR TITLE
Document compare's equality operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ but never tagged, so their links point at the version-bump commits instead.
   `TypeError` instead of `Error` when handed the wrong type. `TypeError` is
   still an `instanceof Error`, so `try`/`catch` is unaffected; only code
   inspecting `err.name` or `err.constructor` will notice.
+- `compare`'s docblock now documents that its equality operators are not
+  JavaScript's. `==` and `!=` are deep structural equality — no coercion, so
+  `1 == "1"` is false, and objects compare by contents, so two separate arrays
+  holding the same values are equal. `===` and `!==` are identity, matching
+  JavaScript except that `NaN` equals itself. Behavior is unchanged; specs were
+  added so the documentation can't drift from the code.
 - `around` iterates its collection with `for...of` rather than `for...in`.
   Identical for the dense arrays it documents; a sparse array, or one carrying
   extra enumerable properties, will iterate differently.

--- a/lib/compare.js
+++ b/lib/compare.js
@@ -3,6 +3,12 @@
 const R = require('ramda');
 
 const operators = {
+  // These four are named after JavaScript's operators but do not behave like
+  // them, in both directions. `R.equals` is deep structural equality: stricter
+  // than JS `==` on primitives, because it never coerces, and looser than JS
+  // `===` on objects, because it compares contents rather than references.
+  // `R.identical` is SameValue, which is JS `===` plus NaN equalling itself.
+  // Documented rather than changed -- see issue #198.
   '==': R.equals,
   '===': R.identical,
   '!=': R.complement(R.equals),
@@ -21,6 +27,21 @@ const operators = {
 
 /**
  * Compare two values using logical operators.
+ *
+ * The operators are named after JavaScript's, but the equality ones do not
+ * behave like JavaScript's, so read this before reaching for `==`.
+ *
+ * `==` and `!=` are **deep structural** equality. No coercion happens, so
+ * `1 == "1"` is false where JavaScript would say true; and objects are compared
+ * by contents, so two separate arrays holding the same values are equal where
+ * JavaScript would say false. This matters most for values arriving from JSON,
+ * front matter, or query strings, where a number may well be a string.
+ *
+ * `===` and `!==` compare identity, matching JavaScript's `===` except that
+ * `NaN` equals itself.
+ *
+ * The relational operators (`<`, `>`, `<=`, `>=`) behave as expected, and
+ * `typeof` compares against a type name such as `"Array"` or `"Number"`.
  *
  * @credit github.com/assemble
  * @param {any} left
@@ -41,6 +62,14 @@ const operators = {
  *
  * {{#compare items "typeof" "Array"}}
  *   The "typeof" operator compares against a type name.
+ * {{/compare}}
+ *
+ * {{#compare 1 "==" "1"}}
+ *   Not rendered: "==" does not coerce, unlike JavaScript's.
+ * {{/compare}}
+ *
+ * {{#compare listA "==" listB}}
+ *   Rendered when both lists hold equal values, even as separate arrays.
  * {{/compare}}
  */
 

--- a/test/compare.spec.js
+++ b/test/compare.spec.js
@@ -13,7 +13,7 @@ tape('compare', (test) => {
   let block;
   let inline;
 
-  test.plan(43);
+  test.plan(50);
 
   // Each operator is checked in both directions. A block helper that only ever
   // gets its truthy case asserted will happily pass with `options.inverse`
@@ -92,6 +92,20 @@ tape('compare', (test) => {
   test.equal(template(block, 'x', 'y'), noMatch, 'Block defaults to === and resolves to false');
   test.equal(template(inline, 'x', 'x'), match, 'Inline defaults to === and resolves to true');
   test.equal(template(inline, 'x', 'y'), noMatch, 'Inline defaults to === and resolves to false');
+
+  // The equality operators are named after JavaScript's but do not behave like
+  // them, in both directions. Pinned here so the docblock cannot drift from the
+  // code -- see issue #198.
+  block = Handlebars.compile('{{#compare a "==" b}}✔︎{{else}}✘{{/compare}}');
+  test.equal(template(block, 1, '1'), noMatch, '== does not coerce, unlike JavaScript');
+  test.equal(template(block, 0, false), noMatch, '== does not coerce 0 to false');
+  test.equal(template(block, null, undefined), noMatch, '== does not equate null and undefined');
+  test.equal(template(block, [1, 2], [1, 2]), match, '== compares arrays structurally');
+  test.equal(template(block, { x: 1 }, { x: 1 }), match, '== compares objects structurally');
+
+  block = Handlebars.compile('{{#compare a "===" b}}✔︎{{else}}✘{{/compare}}');
+  test.equal(template(block, [1, 2], [1, 2]), noMatch, '=== compares identity, not structure');
+  test.equal(template(block, NaN, NaN), match, '=== treats NaN as equal to itself, unlike JavaScript');
 
   block = Handlebars.compile('{{#compare a "foo" b}}✔︎{{/compare}}');
   test.throws(


### PR DESCRIPTION
## Overview

`compare`'s equality operators are named after JavaScript's and behave like neither — in both directions at once. `R.equals` is deep structural equality: stricter than JS `==` on primitives, because it never coerces, and looser than JS `===` on objects, because it compares contents rather than references.

| values | `"=="` | `"==="` | JS `==` | JS `===` |
|---|---|---|---|---|
| `1` vs `"1"` | ✘ | ✘ | ✔︎ | ✘ |
| `0` vs `false` | ✘ | ✘ | ✔︎ | ✘ |
| `null` vs `undefined` | ✘ | ✘ | ✔︎ | ✘ |
| `[1,2]` vs `[1,2]` | ✔︎ | ✘ | ✘ | ✘ |
| `{x:1}` vs `{x:1}` | ✔︎ | ✘ | ✘ | ✘ |
| `NaN` vs `NaN` | ✔︎ | ✔︎ | ✘ | ✘ |

Per the decision on #198 the behavior stays as it is — deep equality is genuinely useful in templates, and changing it would break anyone relying on the structural comparison. What was missing was any statement of what the operators actually *do*. The docblock said "Compare two values using logical operators" and gave a `<` example, so a reader had no way to learn that `{{#compare count "==" 1}}` silently takes the `{{else}}` branch when `count` arrived from JSON as a string. That's the case most likely to bite, since template data routinely comes from JSON, front matter, and query strings.

The seven specs are the part worth reviewing. A docs-only change leaves nothing stopping the code from drifting away from the prose later, and this file has form — before #193 every one of `compare`'s assertions was a positive case with matched types, which is exactly why these semantics went undocumented and unnoticed for nine years. Pinning them means a future change to the operator table fails the suite rather than quietly making the docblock wrong.

Closes #198.

## Screenshots

## Testing

No behavior change, so there's nothing to check in a running app — CI covers the specs. What benefits from human review is whether the documentation is *right*, since that's the entire deliverable:

- [ ] Read the new docblock at the top of `lib/compare.js` and confirm it matches the table above
- [ ] Confirm the wording works for the doxdox site, since that's where this text is published — the description renders above the `@example` blocks
- [ ] Optionally, spot-check a claim in a console: register the helper and render `{{#compare a "==" b}}yes{{else}}no{{/compare}}` with `a: 1, b: "1"` — it should render `no`

Worth a second opinion on one judgment call: the docblock describes the behavior without apologising for it or hinting that it may change. If you'd rather signal that `==` is a candidate for renaming later (option 2 on the issue), a sentence pointing at a future `deepEquals` alias would be easy to add.
