### PR TITLE
Register helpers by literal name in the specs

### DIFF
--- a/test/all.spec.js
+++ b/test/all.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const all = require('../').all;
 
-Handlebars.registerHelper(all.name, all);
+Handlebars.registerHelper('all', all);
 
 tape('all', (test) => {
   const expected = '✔︎';

--- a/test/and.spec.js
+++ b/test/and.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const and = require('../').and;
 
-Handlebars.registerHelper(and.name, and);
+Handlebars.registerHelper('and', and);
 
 tape('and', (test) => {
   const expected = '✔︎';

--- a/test/any.spec.js
+++ b/test/any.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const any = require('../').any;
 
-Handlebars.registerHelper(any.name, any);
+Handlebars.registerHelper('any', any);
 
 tape('any', (test) => {
   const expected = '✔︎';

--- a/test/around.spec.js
+++ b/test/around.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const around = require('../').around;
 
-Handlebars.registerHelper(around.name, around);
+Handlebars.registerHelper('around', around);
 
 tape('around', (test) => {
   let template;

--- a/test/average.spec.js
+++ b/test/average.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const average = require('../').average;
 
-Handlebars.registerHelper(average.name, average);
+Handlebars.registerHelper('average', average);
 
 tape('average', (test) => {
   let template;

--- a/test/capitalize.spec.js
+++ b/test/capitalize.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const capitalize = require('../').capitalize;
 
-Handlebars.registerHelper(capitalize.name, capitalize);
+Handlebars.registerHelper('capitalize', capitalize);
 
 tape('capitalize', (test) => {
   const template = Handlebars.compile('{{capitalize content}}');

--- a/test/capitalizeWords.spec.js
+++ b/test/capitalizeWords.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const capitalizeWords = require('../').capitalizeWords;
 
-Handlebars.registerHelper(capitalizeWords.name, capitalizeWords);
+Handlebars.registerHelper('capitalizeWords', capitalizeWords);
 
 tape('capitalizeWords', (test) => {
   const template = Handlebars.compile('{{{capitalizeWords content}}}');

--- a/test/compare.spec.js
+++ b/test/compare.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const compare = require('../').compare;
 
-Handlebars.registerHelper(compare.name, compare);
+Handlebars.registerHelper('compare', compare);
 
 tape('compare', (test) => {
   const match = '✔︎';

--- a/test/concat.spec.js
+++ b/test/concat.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const concat = require('../').concat;
 
-Handlebars.registerHelper(concat.name, concat);
+Handlebars.registerHelper('concat', concat);
 
 tape('concat', (test) => {
   let template;

--- a/test/defaultTo.spec.js
+++ b/test/defaultTo.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const defaultTo = require('../').defaultTo;
 
-Handlebars.registerHelper(defaultTo.name, defaultTo);
+Handlebars.registerHelper('defaultTo', defaultTo);
 
 tape('defaultTo', (test) => {
   let template;

--- a/test/dummyImgSrc.spec.js
+++ b/test/dummyImgSrc.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const dummyImgSrc = require('../').dummyImgSrc;
 
-Handlebars.registerHelper(dummyImgSrc.name, dummyImgSrc);
+Handlebars.registerHelper('dummyImgSrc', dummyImgSrc);
 
 tape('dummyImgSrc', (test) => {
   let template;

--- a/test/iterate.spec.js
+++ b/test/iterate.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const iterate = require('../').iterate;
 
-Handlebars.registerHelper(iterate.name, iterate);
+Handlebars.registerHelper('iterate', iterate);
 
 tape('iterate', (test) => {
   const template = Handlebars.compile(

--- a/test/math.spec.js
+++ b/test/math.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const math = require('../').math;
 
-Handlebars.registerHelper(math.name, math);
+Handlebars.registerHelper('math', math);
 
 tape('math', (test) => {
   let template;

--- a/test/maybe.spec.js
+++ b/test/maybe.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const maybe = require('../').maybe;
 
-Handlebars.registerHelper(maybe.name, maybe);
+Handlebars.registerHelper('maybe', maybe);
 
 tape('maybe', (test) => {
   const template = Handlebars.compile(

--- a/test/or.spec.js
+++ b/test/or.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const or = require('../').or;
 
-Handlebars.registerHelper(or.name, or);
+Handlebars.registerHelper('or', or);
 
 tape('or', (test) => {
   const expected = '✔︎';

--- a/test/random.spec.js
+++ b/test/random.spec.js
@@ -9,7 +9,7 @@ const random = require('../').random;
 
 const chance = new Chance();
 
-Handlebars.registerHelper(random.name, random);
+Handlebars.registerHelper('random', random);
 
 tape('random', (test) => {
   let template;

--- a/test/randomItem.spec.js
+++ b/test/randomItem.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const randomItem = require('../').randomItem;
 
-Handlebars.registerHelper(randomItem.name, randomItem);
+Handlebars.registerHelper('randomItem', randomItem);
 
 tape('randomItem', (test) => {
   const items = ['a', 'b', 'c'];

--- a/test/replaceAll.spec.js
+++ b/test/replaceAll.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const replaceAll = require('../').replaceAll;
 
-Handlebars.registerHelper(replaceAll.name, replaceAll);
+Handlebars.registerHelper('replaceAll', replaceAll);
 
 tape('replaceAll', (test) => {
   let actual;

--- a/test/split.spec.js
+++ b/test/split.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const split = require('../').split;
 
-Handlebars.registerHelper(split.name, split);
+Handlebars.registerHelper('split', split);
 
 tape('split', (test) => {
   let actual;

--- a/test/svg.spec.js
+++ b/test/svg.spec.js
@@ -7,7 +7,7 @@ const svg = require('../').svg;
 
 const relativeSvg = svg.create({ basePath: './test/fixtures/svg' });
 
-Handlebars.registerHelper(svg.name, svg);
+Handlebars.registerHelper('svg', svg);
 Handlebars.registerHelper('relativeSvg', relativeSvg);
 
 tape('svg', (test) => {

--- a/test/timestamp.spec.js
+++ b/test/timestamp.spec.js
@@ -8,7 +8,7 @@ const tape = require('tape');
 
 const timestamp = require('../').timestamp;
 
-Handlebars.registerHelper(timestamp.name, timestamp);
+Handlebars.registerHelper('timestamp', timestamp);
 
 tape('timestamp', (test) => {
   let template;

--- a/test/toFixed.spec.js
+++ b/test/toFixed.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const toFixed = require('../').toFixed;
 
-Handlebars.registerHelper(toFixed.name, toFixed);
+Handlebars.registerHelper('toFixed', toFixed);
 
 tape('toFixed', (test) => {
   const template = Handlebars.compile('{{toFixed number}}');

--- a/test/toFraction.spec.js
+++ b/test/toFraction.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const toFraction = require('../').toFraction;
 
-Handlebars.registerHelper(toFraction.name, toFraction);
+Handlebars.registerHelper('toFraction', toFraction);
 
 tape('toFraction', (test) => {
   const template = Handlebars.compile('{{{toFraction number}}}');

--- a/test/toJSON.spec.js
+++ b/test/toJSON.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const toJSON = require('../').toJSON;
 
-Handlebars.registerHelper(toJSON.name, toJSON);
+Handlebars.registerHelper('toJSON', toJSON);
 
 tape('toJSON', (test) => {
   let template = Handlebars.compile('{{#each (toJSON data)}}{{this}}{{/each}}');

--- a/test/toSlug.spec.js
+++ b/test/toSlug.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const toSlug = require('../').toSlug;
 
-Handlebars.registerHelper(toSlug.name, toSlug);
+Handlebars.registerHelper('toSlug', toSlug);
 
 tape('toSlug', (test) => {
   const template = Handlebars.compile('{{toSlug title}}');

--- a/test/toTitle.spec.js
+++ b/test/toTitle.spec.js
@@ -5,7 +5,7 @@ const tape = require('tape');
 
 const toTitle = require('../').toTitle;
 
-Handlebars.registerHelper(toTitle.name, toTitle);
+Handlebars.registerHelper('toTitle', toTitle);
 
 tape('toTitle', (test) => {
   const template = Handlebars.compile('{{toTitle title}}');


### PR DESCRIPTION
## Overview

Every spec registers its helper as `Handlebars.registerHelper(and.name, and)`, deriving the name from an internal function identifier. Consumers get something else: `lib/index.js` is `require-dir`, which keys each helper by its **filename**. The two agree across all 26 exports today, and nothing enforces that.

The original 2016 objection was that `.name` on a reference whose identifier is already the string we want is indirection that buys nothing. That still holds, but there's now a concrete failure mode behind it. If a function is renamed inside its file, the specs register the helper under a name the package never ships — and that doesn't reliably fail. Handlebars raises `Missing helper` for a call *with arguments*, but a bare `{{helper}}` is parsed as a property lookup on the context and renders empty:

```
registered as 'randomValue', template says {{random}}
  {{random min=5 max=10}}  →  throws Missing helper
  {{random}}               →  ""            ← no error
```

Renaming `random` to `randomValue` and running the suite on `main` shows it landing:

```
random
  ✔ Works          ← passed against an empty render:
                     Number('') is 0, and 0 is a safe integer
```

The suite only notices on the *following* assertion, and by crashing rather than failing cleanly. Using the literal name means the specs always exercise the name consumers actually receive.

Renaming a *file* — a genuine breaking API change — fails loudly either way, since `require('../').toSlug` becomes `undefined`. That case was never at risk; this is specifically about the function-name half of the pair.

Closes #34.

## Testing

Mechanical, and CI covers it. What's worth confirming by hand is that the change does what it claims, since the whole point is a failure mode the suite couldn't previously see:

- [ ] Run `npm test` — 172 assertions pass, unchanged from `main`
- [ ] On `main`, edit `lib/random.js` to rename the function from `random` to `randomValue` (both the declaration and the `module.exports` line), then run `npm test`. The `random` block reports `✔ Works` before the suite crashes on the next line — a passing assertion for a helper name that doesn't ship
- [ ] Do the same on this branch. The suite passes cleanly, which is correct: renaming an internal function breaks nothing for consumers, and `require('@cloudfour/hbs-helpers').random` still resolves
- [ ] Revert `lib/random.js` either way

## Notes

No CHANGELOG entry — this is test-internal with no consumer-visible effect. The existing test-related entry under `Unreleased` documents new behavioral guarantees; this adds none. Happy to add one if you'd rather record it.

One follow-up worth considering, prompted by the #32 investigation rather than this issue: `lts-patterns` and `cpe-patterns` both import helpers as `@cloudfour/hbs-helpers/lib/${name}.js` from a hardcoded list, so filenames in `lib/` are load-bearing at runtime for them. A single spec asserting the exact set of exported helper names would turn an accidental file rename into a clear failure here rather than a broken build downstream. Out of scope for #34 — say the word and I'll open an issue.
