### PR TITLE
Pin the exported helper names with a spec

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const tape = require('tape');
+
+const helpers = require('../');
+
+// `lib/index.js` is require-dir, so the name of every file in lib/ is a public
+// export name. Downstream repos go further and import
+// `@cloudfour/hbs-helpers/lib/<name>.js` directly from a hardcoded list, which
+// means renaming a file breaks their build at registration time rather than
+// merely changing a key here.
+//
+// This list is deliberately hand-written. Deriving it from the filesystem would
+// make the assertion tautological. Adding a helper means adding it here too --
+// that edit is the point, so a change to the public surface shows up in review.
+const EXPECTED_HELPERS = [
+  'all',
+  'and',
+  'any',
+  'around',
+  'average',
+  'capitalize',
+  'capitalizeWords',
+  'compare',
+  'concat',
+  'defaultTo',
+  'dummyImgSrc',
+  'iterate',
+  'math',
+  'maybe',
+  'or',
+  'random',
+  'randomItem',
+  'replaceAll',
+  'split',
+  'svg',
+  'timestamp',
+  'toFixed',
+  'toFraction',
+  'toJSON',
+  'toSlug',
+  'toTitle',
+];
+
+tape('exports', (test) => {
+  test.plan(4);
+
+  test.deepEqual(
+    Object.keys(helpers).toSorted(),
+    EXPECTED_HELPERS.toSorted(),
+    'Exports exactly the expected set of helpers'
+  );
+
+  test.deepEqual(
+    EXPECTED_HELPERS.filter((name) => typeof helpers[name] !== 'function'),
+    [],
+    'Every helper is a function'
+  );
+
+  // The deep path is API too, because that is what consumers import.
+  test.deepEqual(
+    EXPECTED_HELPERS.filter((name) => {
+      try {
+        return require(`../lib/${name}.js`) !== helpers[name];
+      } catch {
+        return true;
+      }
+    }),
+    [],
+    'Every helper resolves at lib/<name>.js and is the same reference'
+  );
+
+  test.equal(
+    typeof helpers.svg.create,
+    'function',
+    'The svg helper exposes create(), as its docblock documents'
+  );
+});


### PR DESCRIPTION
## Overview

`lib/index.js` is `module.exports = require('require-dir')()`, so the name of every file in `lib/` is a public export name — and `lts-patterns` and `cpe-patterns` go further, interpolating those filenames into runtime imports from a hardcoded list. Nothing tested that surface. Every other spec reaches its helper through `require('../').<name>`, so the export set was only ever asserted incidentally, one helper at a time.

This adds `test/index.spec.js` with four assertions: the export set matches a hand-written list of 26 names, every export is a function, every helper also resolves at `lib/<name>.js` as the same reference, and `svg.create` exists as its docblock documents.

The list is deliberately not derived from the filesystem, which would make the first assertion tautological. Adding a helper now means adding it to that list too — the edit is the point, since it puts "this package's public surface changed" into the diff a reviewer sees.

Closes #205.

## What it does and doesn't catch

Worth being precise, because it's less than the issue implied:

| change | before | after |
|---|---|---|
| helper added, list not updated | silent | **`✖ Exports exactly the expected set of helpers`** |
| helper removed | the helper's own spec crashes | named clearly, plus the crash |
| `lib/<name>.js` deep path breaks | untested | **caught** |
| `svg.create` removed | untested | **caught** |
| file renamed | crash in that helper's spec | crash, usually *before* this spec runs |

The rename row is the honest caveat. On a rename, the affected helper's own spec throws `Missing helper` as an uncaught exception, which kills the whole tape process — so with `dummyImgSrc.js` renamed, `test/dummyImgSrc.spec.js` crashes before `test/index.spec.js` is reached, and you see a Handlebars stack trace rather than the clear assertion. Running `npx tape test/index.spec.js` on its own reports it properly.

Guaranteeing order would mean prefixing the filename to sort first (`00-exports.spec.js` or similar), which breaks the repo's `<helper>.spec.js` convention for every other file. I left the convention alone, but say the word if you'd rather have the ordering guarantee.

So the unique value here is the first, third, and fourth rows: additions, the deep-import path, and `svg.create`. Renames were already loud, just badly diagnosed.

## Testing

CI covers the suite. To confirm the assertions bite:

- [ ] Run `npm test` — 176 assertions pass, up from 172
- [ ] Add a throwaway file to `lib/`, e.g. `lib/probe.js` exporting any function, and run `npm test`. `✖ Exports exactly the expected set of helpers` should fail, listing `probe` as unexpected. Delete it
- [ ] Delete a name from `EXPECTED_HELPERS` in `test/index.spec.js` and run `npm test` — the same assertion should fail from the other direction. Restore it
- [ ] Rename `lib/toSlug.js` to `lib/slugify.js` and run `npx tape test/index.spec.js` — it should name both the missing `toSlug` and the unexpected `slugify`. Then run the full `npm test` to see the caveat above: `test/toSlug.spec.js` crashes first. Rename it back

## Notes

No CHANGELOG entry — test-internal, nothing changes for consumers. Same call as #204; happy to add one if you'd prefer these recorded.
