### PR TITLE
Extend shared Renovate preset

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,10 +1,4 @@
 {
-  "extends": ["config:recommended", ":automergeMinor", ":pinVersions"],
-  "minimumReleaseAge": "3 days",
-  "packageRules": [
-    {
-      "matchDepTypes": ["peerDependencies", "engines"],
-      "rangeStrategy": "replace"
-    }
-  ]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>cloudfour/renovate-config:library"]
 }


### PR DESCRIPTION
## Overview

[`cloudfour/renovate-config`](https://github.com/cloudfour/renovate-config) is now the shared Renovate preset source for Cloud Four repos, so a config change we want everywhere is a one-file edit instead of a hand-edit across two dozen repos. This replaces the local config with a one-line `extends`.

This repo extends the `library` preset because it publishes to npm. `library` is the shared default plus a rule keeping `peerDependencies` and `engines` as ranges instead of pinning them — which is exactly the rule this repo used to declare by hand, so it's now inherited rather than duplicated. Nothing else here was doing work the shared config doesn't already do, so no local `packageRules` remain.

Behavior is unchanged: same auto-merge policy, same three-day release cooldown, same range handling for published metadata.

## Screenshots

## Testing

- [ ] Open `.renovaterc.json` on this branch — it should contain only a `$schema` line and a single `extends` entry pointing at `local>cloudfour/renovate-config:library`
- [ ] After merging, open the **Dependency Dashboard** issue and wait for Renovate to run (or tick the checkbox at the bottom of the dashboard to request an immediate run)
- [ ] The dashboard should render its usual list of pending updates with no error banner at the top. A red "Config Validation" or "Preset Not Found" warning would mean the preset failed to resolve
- [ ] On the next dependency PR, confirm patch and minor updates are still set to auto-merge and that updates don't appear until three days after release

---

Part of cloudfour/renovate-config#1
